### PR TITLE
fix: 상위 컴포넌트에서 event를 직접 사용하도록 수정

### DIFF
--- a/src/components/basic/Input/index.jsx
+++ b/src/components/basic/Input/index.jsx
@@ -70,7 +70,7 @@ const Input = ({
 
   const handleChange = useCallback(
     (e) => {
-      onChange && onChange(e.target.value);
+      onChange && onChange(e);
     },
     [onChange],
   );


### PR DESCRIPTION
## PR 템플릿
## ✅ 이슈 번호
#2
## 📌 기능 설명 

현재 상위 컴포넌트에서 submit 시 event 객체를 직접 조작할 예정이라 event.target.value 대신 event를 넘기도록 수정

