### PR TITLE
feat: PostImageList

### DIFF
--- a/src/components/PostImageList/index.jsx
+++ b/src/components/PostImageList/index.jsx
@@ -1,0 +1,21 @@
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+
+const ImageContainer = styled.div`
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, 30%);
+  gap: 10px;
+  justify-content: center;
+  margin-top: 10px;
+`;
+
+const PostImageList = ({ children, ...props }) => {
+  return <ImageContainer style={{ ...props.style }}>{children}</ImageContainer>;
+};
+
+export default PostImageList;
+
+PostImageList.propTypes = {
+  children: PropTypes.node,
+};

--- a/src/stories/components/PostImageList.stories.jsx
+++ b/src/stories/components/PostImageList.stories.jsx
@@ -1,0 +1,55 @@
+import PostImageList from 'components/PostImageList';
+import Image from 'components/basic/Image';
+
+export default {
+  title: 'Components/PostImageList',
+  component: PostImageList,
+  argTypes: {
+    width: {
+      defaultValue: 500,
+      control: { type: 'range', min: 300, max: 500 },
+    },
+    lazy: {
+      defaultValue: false,
+      control: { type: 'boolean' },
+    },
+    src: {
+      type: { name: 'string', require: true },
+      defaultValue: 'https://picsum.photos/200',
+      control: { type: 'text' },
+    },
+    placeholder: {
+      type: { name: 'string' },
+      defaultValue: 'https://via.placeholder.com/200',
+      control: { type: 'text' },
+    },
+    threshold: {
+      type: { name: 'number' },
+      defaultValue: 0.5,
+      control: { type: 'number' },
+    },
+    mode: {
+      defaultValue: 'cover',
+      options: ['cover', 'fill', 'contain'],
+      control: { type: 'inline-radio' },
+    },
+  },
+};
+
+export const Default = (args) => {
+  return (
+    <PostImageList style={{ ...args }}>
+      {Array.from(new Array(70), (_, k) => k).map((i) => (
+        <Image
+          width="100%"
+          lazy={args.lazy}
+          block={true}
+          placeholder={args.placeholder}
+          threshold={args.threshold}
+          src={`${args.src}?${i}`}
+          key={i}
+        />
+      ))}
+    </PostImageList>
+  );
+};


### PR DESCRIPTION
## PR 템플릿
## ✅ 이슈 번호
#58 

## 📌 기능 설명 

검색결과, 마이페이지 포스트 이미지 리스트 담는 컨테이너

## 👩‍💻 요구 사항과 구현 내용 

### props

` {children, ...props }` 두 개만 받고 있습니다. 

- children : 혹시 이미지가 없는 경우를 생각해서 children을 isRequired로 두지 않았습니다.  
이미지가 있다면 이미지 컴포넌트에 아래 속성을 넣어주세요

```js
    width="100%"
    block={true}
```

-  해당 컴포넌트는 다음과 같이 스타일을 고정해 뒀습니다. 만약 바꾸고 싶다면 인라인 style을 사용해주세요.

```js
const ImageContainer = styled.div`
  width: 100%;
  display: grid;
  grid-template-columns: repeat(3, 30%);
  gap: 10px;
  justify-content: center;
  margin-top: 10px;
`;
```

## 구현 결과

뷰포트 확인을 위해 스토리북에선 해당 컴포넌트의 width를 조정하게 했으나 100%가 고정값입니다. 

![image](https://user-images.githubusercontent.com/79133602/173524175-dde47225-fcfe-4f79-a9c3-fa435bd51719.png)

