### PR TITLE
feat: 게시물 등록 페이지(PostAddPage) 구현

### DIFF
--- a/src/components/InputForm/InputFormButton.jsx
+++ b/src/components/InputForm/InputFormButton.jsx
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled';
+import Button from '../basic/Button';
+
+const StyledButton = styled(Button)`
+  font-size: ${({ fontSize }) => fontSize};
+  background-color: #30a57d;
+  color: white;
+  padding: 0 16px;
+  font-size: 18px;
+  border-radius: 10px;
+`;
+
+const InputFormButton = ({ children, ...props }) => {
+  return (
+    <StyledButton
+      type="submit"
+      width="auto"
+      height={46}
+      borderRadius={12}
+      fontWeight={500}
+      {...props}
+    >
+      {children}
+    </StyledButton>
+  );
+};
+
+export default InputFormButton;

--- a/src/components/InputForm/InputFormInput.jsx
+++ b/src/components/InputForm/InputFormInput.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import theme from 'styles/theme';
+
+const { fontNormal } = theme.color;
+const StyledInput = styled.input`
+  font-size: 20px;
+  border: none;
+  width: 100%;
+  min-height: 46px;
+  box-sizing: border-box;
+  padding-left: 10px;
+  padding-right: 20px;
+  background-color: transparent;
+
+  ::placeholder {
+    color: ${fontNormal};
+  }
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const InputFormInput = ({ placeholder, onChange, value, ...props }) => {
+  const handleChange = (e) => {
+    onChange && onChange(e);
+  };
+  return (
+    <>
+      <StyledInput
+        placeholder={placeholder}
+        value={value}
+        onChange={handleChange}
+        {...props}
+      />
+    </>
+  );
+};
+
+export default InputFormInput;

--- a/src/components/InputForm/index.jsx
+++ b/src/components/InputForm/index.jsx
@@ -1,0 +1,39 @@
+import styled from '@emotion/styled';
+import Input from './InputFormInput';
+import Button from './InputFormButton';
+import theme from 'styles/theme';
+
+const { mainRed, borderNormal } = theme.color;
+const StyledInner = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px;
+  border-radius: 15px;
+  box-sizing: border-box;
+  border: 1px solid ${borderNormal};
+`;
+
+const Error = styled.p`
+  margin-top: 15px;
+  color: ${mainRed};
+`;
+
+const InputForm = ({ children, error, onSubmit, ...props }) => {
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit && onSubmit(e);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <StyledInner {...props}>{children}</StyledInner>
+      <Error>{error && error}</Error>
+    </form>
+  );
+};
+
+InputForm.Input = Input;
+InputForm.Button = Button;
+
+export default InputForm;

--- a/src/components/InputForm/index.jsx
+++ b/src/components/InputForm/index.jsx
@@ -15,7 +15,7 @@ const StyledInner = styled.div`
 `;
 
 const Error = styled.p`
-  margin-top: 15px;
+  margin: 15px 0;
   color: ${mainRed};
 `;
 

--- a/src/components/TagAddForm/index.jsx
+++ b/src/components/TagAddForm/index.jsx
@@ -1,0 +1,74 @@
+import styled from '@emotion/styled';
+import useValidInput from 'hooks/useValidInput';
+import InputForm from 'components/InputForm';
+import Text from 'components/basic/Text';
+import Icon from 'components/basic/Icon';
+
+import theme from 'styles/theme';
+
+const { mainGreen } = theme.color;
+
+const TagList = styled.ul`
+  display: flex;
+  flex-wrap: wrap;
+`;
+
+const TagItem = styled.li`
+  padding: 5px 13px;
+  border: 1px solid ${mainGreen};
+  border-radius: 15px;
+  white-space: nowrap;
+  margin: 0 4px 4px 0;
+  color: ${mainGreen};
+  display: flex;
+  align-items: center;
+`;
+
+const RemoveBtn = styled.button``;
+
+const TagAddForm = ({ onAddTag, onRemoveTag, tags }) => {
+  const { value, resetValue, error, setError, handleChange } = useValidInput(6);
+
+  const handleRemoveTag = (index) => {
+    onRemoveTag(index);
+    setError('');
+  };
+
+  const onSubmit = () => {
+    setError('');
+    onAddTag(value);
+    resetValue();
+  };
+
+  return (
+    <>
+      <InputForm
+        onSubmit={onSubmit}
+        error={error}
+        style={{ marginTop: '15px' }}
+      >
+        <InputForm.Input
+          placeholder="태그를 입력해주세요"
+          onChange={handleChange}
+          value={value}
+        />
+        <InputForm.Button>등록</InputForm.Button>
+      </InputForm>
+
+      <TagList>
+        {tags.map((tag, index) => (
+          <TagItem key={index}>
+            <Text block fontSize={16} style={{ marginBottom: '2px' }}>
+              {tag}
+            </Text>
+            <RemoveBtn onClick={() => handleRemoveTag(index)}>
+              <Icon name="TAG_DELETE" size={8}></Icon>
+            </RemoveBtn>
+          </TagItem>
+        ))}
+      </TagList>
+    </>
+  );
+};
+
+export default TagAddForm;

--- a/src/components/TagAddForm/index.jsx
+++ b/src/components/TagAddForm/index.jsx
@@ -6,7 +6,7 @@ import Icon from 'components/basic/Icon';
 
 import theme from 'styles/theme';
 
-const { mainGreen } = theme.color;
+const { mainGreen, fontNormal } = theme.color;
 
 const TagList = styled.ul`
   display: flex;
@@ -54,6 +54,15 @@ const TagAddForm = ({ onAddTag, onRemoveTag, tags }) => {
         />
         <InputForm.Button>등록</InputForm.Button>
       </InputForm>
+
+      <Text
+        fontSize={16}
+        color={fontNormal}
+        block
+        style={{ marginTop: '15px', marginBottom: '15px' }}
+      >
+        * 태그는 최대 5개까지 입력 가능합니다.
+      </Text>
 
       <TagList>
         {tags.map((tag, index) => (

--- a/src/components/UploadImage/index.jsx
+++ b/src/components/UploadImage/index.jsx
@@ -1,8 +1,8 @@
 import { useRef, useState } from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
-
 import theme from 'styles/theme';
+
 const { backgroundGreen } = theme.color;
 
 const ImageLoad = styled.div`
@@ -27,7 +27,8 @@ const ImageInner = styled.div`
   width: 100%;
   height: 100%;
   background-position: center;
-  background-size: 100%;
+  background-size: cover;
+  background-repeat: no-repeat;
   /* background-color: white; */
 `;
 

--- a/src/components/UploadImage/index.jsx
+++ b/src/components/UploadImage/index.jsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react';
 import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
 
 import theme from 'styles/theme';
 const { backgroundGreen } = theme.color;
@@ -60,6 +61,11 @@ const UploadImage = ({ onChange, defaultImage = null, ...props }) => {
       />
     </div>
   );
+};
+
+UploadImage.propTypes = {
+  onChange: PropTypes.func,
+  defaultImage: PropTypes.string,
 };
 
 export default UploadImage;

--- a/src/components/UploadImage/index.jsx
+++ b/src/components/UploadImage/index.jsx
@@ -1,0 +1,65 @@
+import { useRef, useState } from 'react';
+import styled from '@emotion/styled';
+
+import theme from 'styles/theme';
+const { backgroundGreen } = theme.color;
+
+const ImageLoad = styled.div`
+  width: 100%;
+  background-color: ${backgroundGreen};
+  position: relative;
+  cursor: pointer;
+
+  &:after {
+    content: '';
+    display: block;
+    padding-bottom: 100%;
+  }
+`;
+
+const FileInput = styled.input`
+  display: none;
+`;
+
+const ImageInner = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-position: center;
+  background-size: 100%;
+  /* background-color: white; */
+`;
+
+const UploadImage = ({ onChange, defaultImage = null, ...props }) => {
+  const [imageSrc, setImageSrc] = useState(defaultImage);
+  const fileInputRef = useRef(null);
+
+  const handleFileChange = (e) => {
+    const fileBlob = e.target.files[0];
+    const reader = new FileReader();
+    reader.readAsDataURL(fileBlob);
+    reader.onload = () => {
+      setImageSrc(reader.result);
+      onChange(reader.result);
+    };
+  };
+
+  return (
+    <div>
+      <ImageLoad
+        onClick={() => fileInputRef.current.click()}
+        style={{ ...props.style }}
+      >
+        <ImageInner style={{ backgroundImage: `url(${imageSrc})` }} />
+      </ImageLoad>
+      <FileInput
+        ref={fileInputRef}
+        type="file"
+        id="file"
+        onChange={handleFileChange}
+      />
+    </div>
+  );
+};
+
+export default UploadImage;

--- a/src/components/basic/Text/index.jsx
+++ b/src/components/basic/Text/index.jsx
@@ -34,11 +34,7 @@ const Text = ({
     children = <del>{children}</del>;
   }
 
-  return (
-    <Tag style={{ ...props.style, ...fontStyle }} {...props}>
-      {children}
-    </Tag>
-  );
+  return <Tag style={{ ...props.style, ...fontStyle }}>{children}</Tag>;
 };
 
 Text.propTypes = {

--- a/src/hooks/useValidInput.js
+++ b/src/hooks/useValidInput.js
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+
+const useValidInput = (max = 0) => {
+  const [error, setError] = useState('');
+  const [inputValue, setInputValue] = useState('');
+
+  const handleChange = (e) => {
+    const value = e.target.value;
+
+    // eslint-disable-next-line
+    const reg = /[`~!@#$%^&*()_|+\-=?;:'",.<>\s\{\}\[\]\\\/]/gi;
+
+    if (max && inputValue.length > max) {
+      setError(`* 1-${max}글자 사이로 입력해주세요!`);
+      setInputValue(value.slice(0, max + 1));
+      return;
+    }
+    if (reg.test(value)) {
+      setError('* 특수문자 및 띄어쓰기는 사용할 수 없습니다.');
+      setInputValue(value.replace(reg, ''));
+      return;
+    }
+
+    setInputValue(value);
+    setError('');
+  };
+
+  return {
+    inputValue,
+    error,
+    setError,
+    handleChange,
+  };
+};
+
+export default useValidInput;

--- a/src/hooks/useValidInput.js
+++ b/src/hooks/useValidInput.js
@@ -2,33 +2,38 @@ import { useState } from 'react';
 
 const useValidInput = (max = 0) => {
   const [error, setError] = useState('');
-  const [inputValue, setInputValue] = useState('');
+  const [value, setValue] = useState('');
 
   const handleChange = (e) => {
-    const value = e.target.value;
+    const inputValue = e.target.value;
 
     // eslint-disable-next-line
     const reg = /[`~!@#$%^&*()_|+\-=?;:'",.<>\s\{\}\[\]\\\/]/gi;
 
-    if (max && inputValue.length > max) {
+    if (max && value.length >= max) {
       setError(`* 1-${max}글자 사이로 입력해주세요!`);
-      setInputValue(value.slice(0, max + 1));
+      setValue(inputValue.slice(0, max));
       return;
     }
-    if (reg.test(value)) {
+    if (reg.test(inputValue)) {
       setError('* 특수문자 및 띄어쓰기는 사용할 수 없습니다.');
-      setInputValue(value.replace(reg, ''));
+      setValue(inputValue.replace(reg, ''));
       return;
     }
 
-    setInputValue(value);
+    setValue(inputValue);
     setError('');
   };
 
+  const resetValue = () => {
+    setValue('');
+  };
+
   return {
-    inputValue,
+    value,
     error,
     setError,
+    resetValue,
     handleChange,
   };
 };

--- a/src/pages/PostAddPage/index.jsx
+++ b/src/pages/PostAddPage/index.jsx
@@ -1,5 +1,95 @@
+import styled from '@emotion/styled';
+import Button from 'components/basic/Button';
+import Image from 'components/basic/Image';
+import InputForm from 'components/basic/Input/InputForm';
+import Text from 'components/basic/Text';
+import { useState } from 'react';
+import theme from 'styles/theme';
+
+const { fontNormal, mainGreen, backgroundGreen, borderNormal } = theme.color;
+
+const ImageLoad = styled.div`
+  width: 100%;
+  background-color: ${backgroundGreen};
+
+  &:after {
+    content: '';
+    display: block;
+    padding-bottom: 100%;
+  }
+`;
+const TagList = styled.ul`
+  display: flex;
+  flex-wrap: wrap;
+`;
+const TagItem = styled.li`
+  padding: 5px 13px;
+  border: 1px solid ${mainGreen};
+  border-radius: 15px;
+  color: ${mainGreen};
+  white-space: nowrap;
+  margin: 0 4px 4px 0;
+`;
+
+const TextArea = styled.textarea`
+  margin-top: 20px;
+  width: 100%;
+  border: 1px solid ${borderNormal};
+  border-radius: 15px;
+  padding: 23px 20px;
+  resize: none;
+  font-size: 20px;
+  color: ${fontNormal};
+
+  ::placeholder {
+    color: ${fontNormal};
+  }
+`;
+
 const PostAddPage = () => {
-  return <div>PostAddPage</div>;
+  const [tags, setTags] = useState([]);
+
+  const onSubmit = (value) => {
+    setTags((state) => [...state, value]);
+    console.log(value);
+  };
+  return (
+    <>
+      <ImageLoad></ImageLoad>
+      <InputForm
+        name="tag"
+        placeholder="태그를 입력해 주세요"
+        enterButton="등록"
+        fontSize="18px"
+        onSubmit={onSubmit}
+        style={{ marginTop: '15px' }}
+      />
+      <Text
+        fontSize={16}
+        color={fontNormal}
+        block
+        style={{ marginTop: '15px', marginBottom: '15px' }}
+      >
+        * 태그는 최대 5개까지 입력 가능합니다.
+      </Text>
+
+      <TagList>
+        {tags.map((tag, index) => (
+          <TagItem key={index}>
+            {tag}
+            <button>x</button>
+          </TagItem>
+        ))}
+      </TagList>
+      <TextArea
+        placeholder="내 식물의 성장 글을 작성해주세요."
+        rows={10}
+      ></TextArea>
+      <Button style={{ marginTop: '15px', marginBottom: '15px' }}>
+        게시물 등록
+      </Button>
+    </>
+  );
 };
 
 export default PostAddPage;

--- a/src/pages/PostAddPage/index.jsx
+++ b/src/pages/PostAddPage/index.jsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled';
+import axios from 'axios';
 import Button from 'components/basic/Button';
 import Image from 'components/basic/Image';
 import InputForm from 'components/basic/Input/InputForm';
 import Text from 'components/basic/Text';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import theme from 'styles/theme';
 
 const { fontNormal, mainGreen, backgroundGreen, borderNormal, mainBlack } =
@@ -12,13 +13,23 @@ const { fontNormal, mainGreen, backgroundGreen, borderNormal, mainBlack } =
 const ImageLoad = styled.div`
   width: 100%;
   background-color: ${backgroundGreen};
-
+  position: relative;
   &:after {
     content: '';
     display: block;
     padding-bottom: 100%;
   }
 `;
+
+const ImageInner = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-position: center;
+  background-size: 100%;
+  background-color: white;
+`;
+
 const TagList = styled.ul`
   display: flex;
   flex-wrap: wrap;
@@ -50,10 +61,11 @@ const RemoveBtn = styled.button``;
 
 const PostAddPage = () => {
   const [tags, setTags] = useState([]);
+  const [imgSrc, setImgSrc] = useState('');
+  const [text, setText] = useState('');
 
   const onSubmit = (value) => {
     setTags((state) => [...state, value]);
-    console.log(value);
   };
 
   const onRemoveTag = (index) => {
@@ -61,9 +73,24 @@ const PostAddPage = () => {
     setTags(updateTags);
   };
 
+  const onClickAddBtn = () => {};
+
+  const onFileReader = (e) => {
+    const fileBlob = e.target.files[0];
+    const reader = new FileReader();
+    reader.readAsDataURL(fileBlob);
+    reader.onload = () => {
+      setImgSrc(reader.result);
+    };
+  };
+
   return (
     <>
-      <ImageLoad></ImageLoad>
+      <ImageLoad>
+        <ImageInner style={{ backgroundImage: `url(${imgSrc})` }} />
+      </ImageLoad>
+      <input type="file" id="file" onChange={onFileReader} />
+
       <InputForm
         name="tag"
         placeholder="태그를 입력해 주세요"
@@ -90,10 +117,16 @@ const PostAddPage = () => {
         ))}
       </TagList>
       <TextArea
+        onChange={(e) => {
+          setText(e.target.value);
+        }}
         placeholder="내 식물의 성장 글을 작성해주세요."
         rows={10}
       ></TextArea>
-      <Button style={{ marginTop: '15px', marginBottom: '15px' }}>
+      <Button
+        style={{ marginTop: '15px', marginBottom: '15px' }}
+        onClick={onClickAddBtn}
+      >
         게시물 등록
       </Button>
     </>

--- a/src/pages/PostAddPage/index.jsx
+++ b/src/pages/PostAddPage/index.jsx
@@ -1,30 +1,17 @@
 import { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 import axios from 'axios';
 import Button from 'components/basic/Button';
-import InputForm from 'components/basic/Input/InputForm';
 import Text from 'components/basic/Text';
-import theme from 'styles/theme';
 import UploadImage from 'components/UploadImage';
+import TagAddForm from 'components/TagAddForm';
+import theme from 'styles/theme';
 
-const { fontNormal, mainGreen, borderNormal, mainBlack } = theme.color;
+const { fontNormal, borderNormal, mainBlack } = theme.color;
 
 const Wrapper = styled.div`
   padding: 0 20px;
-`;
-
-const TagList = styled.ul`
-  display: flex;
-  flex-wrap: wrap;
-`;
-
-const TagItem = styled.li`
-  padding: 5px 13px;
-  border: 1px solid ${mainGreen};
-  border-radius: 15px;
-  white-space: nowrap;
-  margin: 0 4px 4px 0;
-  color: ${mainGreen};
 `;
 
 const TextArea = styled.textarea`
@@ -45,8 +32,7 @@ const TextArea = styled.textarea`
 /*
   TODO:
   태그 등록 완료 시 input 초기화
-  태그 특수문자 제한
-  태그 입력 시 자동으로 # 앞에 붙이게 처리
+  태그 특수문자 및 띄어쓰기 제한
   게시물 등록 시 페이지 이동
 */
 
@@ -71,34 +57,41 @@ const handleDataForm = async ({ text, tags, imgSrc }) => {
 
   const headers = {
     'Content-Type': 'multipart/form-data',
-    Authorization:
-      'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7Il9pZCI6IjYyYTc1ZTVjYjFiOTBiMGM4MTJjOWI3MCIsImVtYWlsIjoiMzI1QG5hdmVyLmNvbSJ9LCJpYXQiOjE2NTUxMzYyMTd9.w4YDSceQD83VMiKaTnJYEmcDEKNQAWT1Al9iyFGEL74',
+    Authorization: `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7Il9pZCI6IjYyYTc1ZTVjYjFiOTBiMGM4MTJjOWI3MCIsImVtYWlsIjoiMzI1QG5hdmVyLmNvbSJ9LCJpYXQiOjE2NTUxMzYyMTd9.w4YDSceQD83VMiKaTnJYEmcDEKNQAWT1Al9iyFGEL74`,
   };
 
   const result = await axios.post(`/posts/create`, formData, { headers });
   console.log(result);
 };
 
-const RemoveBtn = styled.button``;
-
 const PostAddPage = () => {
   const [tags, setTags] = useState([]);
   const [imgSrc, setImgSrc] = useState('');
   const [text, setText] = useState('');
 
-  const onAddTag = (value) => {
-    const tag = `#${value}`;
-    setTags((state) => [...state, tag]);
-    console.log(tags);
-  };
+  const navigate = useNavigate();
 
-  const onRemoveTag = (index) => {
-    const updateTags = tags.filter((_, itemIndex) => itemIndex !== index);
-    setTags(updateTags);
-  };
+  const onAddTag = useCallback(
+    (value) => {
+      const tag = `#${value}`;
+      if (tags.length < 5) {
+        setTags([...tags, tag]);
+      }
+    },
+    [tags],
+  );
 
-  const onClickAddBtn = () => {
-    handleDataForm({ text, tags, imgSrc });
+  const onRemoveTag = useCallback(
+    (index) => {
+      const updateTags = tags.filter((_, itemIndex) => itemIndex !== index);
+      setTags(updateTags);
+    },
+    [tags],
+  );
+
+  const onClickAddBtn = async () => {
+    await handleDataForm({ text, tags, imgSrc });
+    navigate('/');
   };
 
   const onFileChange = useCallback((src) => {
@@ -109,14 +102,8 @@ const PostAddPage = () => {
     <>
       <UploadImage onChange={onFileChange} />
       <Wrapper>
-        <InputForm
-          name="tag"
-          placeholder="태그를 입력해 주세요"
-          enterButton="등록"
-          fontSize="18px"
-          onSubmit={onAddTag}
-          style={{ marginTop: '15px' }}
-        />
+        <TagAddForm onAddTag={onAddTag} onRemoveTag={onRemoveTag} tags={tags} />
+
         <Text
           fontSize={16}
           color={fontNormal}
@@ -126,14 +113,6 @@ const PostAddPage = () => {
           * 태그는 최대 5개까지 입력 가능합니다.
         </Text>
 
-        <TagList>
-          {tags.map((tag, index) => (
-            <TagItem key={index}>
-              {tag}
-              <RemoveBtn onClick={() => onRemoveTag(index)}>x</RemoveBtn>
-            </TagItem>
-          ))}
-        </TagList>
         <TextArea
           onChange={(e) => {
             setText(e.target.value);

--- a/src/pages/PostAddPage/index.jsx
+++ b/src/pages/PostAddPage/index.jsx
@@ -57,6 +57,36 @@ const TextArea = styled.textarea`
   }
 `;
 
+const handleDataForm = async ({ text, tags, imgSrc }) => {
+  // 변환한 데이터 앞 부분 자르기
+  const byteString = atob(imgSrc.split(',')[1]);
+  const title = { content: text, tags };
+
+  const ab = new ArrayBuffer(byteString.length);
+  const ia = new Uint8Array(ab);
+
+  for (let i = 0; i < byteString.length; i++) {
+    ia[i] = byteString.charCodeAt(i);
+  }
+  const blob = new Blob([ia], {
+    type: 'image/jpeg',
+  });
+
+  const formData = new FormData();
+  formData.append('image', blob);
+  formData.append('title', JSON.stringify(title));
+  formData.append('channelId', process.env.REACT_APP_CHANNEL_ID_TOTAL);
+
+  const headers = {
+    'Content-Type': 'multipart/form-data',
+    Authorization:
+      'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7Il9pZCI6IjYyYTc1ZTVjYjFiOTBiMGM4MTJjOWI3MCIsImVtYWlsIjoiMzI1QG5hdmVyLmNvbSJ9LCJpYXQiOjE2NTUxMzYyMTd9.w4YDSceQD83VMiKaTnJYEmcDEKNQAWT1Al9iyFGEL74',
+  };
+
+  const result = await axios.post(`/posts/create`, formData, { headers });
+  console.log(result);
+};
+
 const RemoveBtn = styled.button``;
 
 const PostAddPage = () => {
@@ -73,7 +103,9 @@ const PostAddPage = () => {
     setTags(updateTags);
   };
 
-  const onClickAddBtn = () => {};
+  const onClickAddBtn = () => {
+    handleDataForm({ text, tags, imgSrc });
+  };
 
   const onFileReader = (e) => {
     const fileBlob = e.target.files[0];

--- a/src/pages/PostAddPage/index.jsx
+++ b/src/pages/PostAddPage/index.jsx
@@ -29,13 +29,6 @@ const TextArea = styled.textarea`
   }
 `;
 
-/*
-  TODO:
-  태그 등록 완료 시 input 초기화
-  태그 특수문자 및 띄어쓰기 제한
-  게시물 등록 시 페이지 이동
-*/
-
 const handleDataForm = async ({ text, tags, imgSrc }) => {
   const byteString = atob(imgSrc.split(',')[1]);
   const title = { content: text, tags };

--- a/src/pages/PostAddPage/index.jsx
+++ b/src/pages/PostAddPage/index.jsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 import axios from 'axios';
 import Button from 'components/basic/Button';
-import Text from 'components/basic/Text';
 import UploadImage from 'components/UploadImage';
 import TagAddForm from 'components/TagAddForm';
 import theme from 'styles/theme';
@@ -96,16 +95,6 @@ const PostAddPage = () => {
       <UploadImage onChange={onFileChange} />
       <Wrapper>
         <TagAddForm onAddTag={onAddTag} onRemoveTag={onRemoveTag} tags={tags} />
-
-        <Text
-          fontSize={16}
-          color={fontNormal}
-          block
-          style={{ marginTop: '15px', marginBottom: '15px' }}
-        >
-          * 태그는 최대 5개까지 입력 가능합니다.
-        </Text>
-
         <TextArea
           onChange={(e) => {
             setText(e.target.value);

--- a/src/pages/PostAddPage/index.jsx
+++ b/src/pages/PostAddPage/index.jsx
@@ -1,45 +1,30 @@
+import { useCallback, useState } from 'react';
 import styled from '@emotion/styled';
 import axios from 'axios';
 import Button from 'components/basic/Button';
-import Image from 'components/basic/Image';
 import InputForm from 'components/basic/Input/InputForm';
 import Text from 'components/basic/Text';
-import { useRef, useState } from 'react';
 import theme from 'styles/theme';
+import UploadImage from 'components/UploadImage';
 
-const { fontNormal, mainGreen, backgroundGreen, borderNormal, mainBlack } =
-  theme.color;
+const { fontNormal, mainGreen, borderNormal, mainBlack } = theme.color;
 
-const ImageLoad = styled.div`
-  width: 100%;
-  background-color: ${backgroundGreen};
-  position: relative;
-  &:after {
-    content: '';
-    display: block;
-    padding-bottom: 100%;
-  }
-`;
-
-const ImageInner = styled.div`
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background-position: center;
-  background-size: 100%;
-  background-color: white;
+const Wrapper = styled.div`
+  padding: 0 20px;
 `;
 
 const TagList = styled.ul`
   display: flex;
   flex-wrap: wrap;
 `;
+
 const TagItem = styled.li`
   padding: 5px 13px;
   border: 1px solid ${mainGreen};
   border-radius: 15px;
   white-space: nowrap;
   margin: 0 4px 4px 0;
+  color: ${mainGreen};
 `;
 
 const TextArea = styled.textarea`
@@ -57,8 +42,15 @@ const TextArea = styled.textarea`
   }
 `;
 
+/*
+  TODO:
+  태그 등록 완료 시 input 초기화
+  태그 특수문자 제한
+  태그 입력 시 자동으로 # 앞에 붙이게 처리
+  게시물 등록 시 페이지 이동
+*/
+
 const handleDataForm = async ({ text, tags, imgSrc }) => {
-  // 변환한 데이터 앞 부분 자르기
   const byteString = atob(imgSrc.split(',')[1]);
   const title = { content: text, tags };
 
@@ -94,8 +86,10 @@ const PostAddPage = () => {
   const [imgSrc, setImgSrc] = useState('');
   const [text, setText] = useState('');
 
-  const onSubmit = (value) => {
-    setTags((state) => [...state, value]);
+  const onAddTag = (value) => {
+    const tag = `#${value}`;
+    setTags((state) => [...state, tag]);
+    console.log(tags);
   };
 
   const onRemoveTag = (index) => {
@@ -107,54 +101,47 @@ const PostAddPage = () => {
     handleDataForm({ text, tags, imgSrc });
   };
 
-  const onFileReader = (e) => {
-    const fileBlob = e.target.files[0];
-    const reader = new FileReader();
-    reader.readAsDataURL(fileBlob);
-    reader.onload = () => {
-      setImgSrc(reader.result);
-    };
-  };
+  const onFileChange = useCallback((src) => {
+    setImgSrc(src);
+  }, []);
 
   return (
     <>
-      <ImageLoad>
-        <ImageInner style={{ backgroundImage: `url(${imgSrc})` }} />
-      </ImageLoad>
-      <input type="file" id="file" onChange={onFileReader} />
+      <UploadImage onChange={onFileChange} />
+      <Wrapper>
+        <InputForm
+          name="tag"
+          placeholder="태그를 입력해 주세요"
+          enterButton="등록"
+          fontSize="18px"
+          onSubmit={onAddTag}
+          style={{ marginTop: '15px' }}
+        />
+        <Text
+          fontSize={16}
+          color={fontNormal}
+          block
+          style={{ marginTop: '15px', marginBottom: '15px' }}
+        >
+          * 태그는 최대 5개까지 입력 가능합니다.
+        </Text>
 
-      <InputForm
-        name="tag"
-        placeholder="태그를 입력해 주세요"
-        enterButton="등록"
-        fontSize="18px"
-        onSubmit={onSubmit}
-        style={{ marginTop: '15px' }}
-      />
-      <Text
-        fontSize={16}
-        color={fontNormal}
-        block
-        style={{ marginTop: '15px', marginBottom: '15px' }}
-      >
-        * 태그는 최대 5개까지 입력 가능합니다.
-      </Text>
-
-      <TagList>
-        {tags.map((tag, index) => (
-          <TagItem key={index}>
-            {tag}
-            <RemoveBtn onClick={() => onRemoveTag(index)}>x</RemoveBtn>
-          </TagItem>
-        ))}
-      </TagList>
-      <TextArea
-        onChange={(e) => {
-          setText(e.target.value);
-        }}
-        placeholder="내 식물의 성장 글을 작성해주세요."
-        rows={10}
-      ></TextArea>
+        <TagList>
+          {tags.map((tag, index) => (
+            <TagItem key={index}>
+              {tag}
+              <RemoveBtn onClick={() => onRemoveTag(index)}>x</RemoveBtn>
+            </TagItem>
+          ))}
+        </TagList>
+        <TextArea
+          onChange={(e) => {
+            setText(e.target.value);
+          }}
+          placeholder="내 식물의 성장 글을 작성해주세요."
+          rows={10}
+        ></TextArea>
+      </Wrapper>
       <Button
         style={{ marginTop: '15px', marginBottom: '15px' }}
         onClick={onClickAddBtn}

--- a/src/pages/PostAddPage/index.jsx
+++ b/src/pages/PostAddPage/index.jsx
@@ -6,7 +6,8 @@ import Text from 'components/basic/Text';
 import { useState } from 'react';
 import theme from 'styles/theme';
 
-const { fontNormal, mainGreen, backgroundGreen, borderNormal } = theme.color;
+const { fontNormal, mainGreen, backgroundGreen, borderNormal, mainBlack } =
+  theme.color;
 
 const ImageLoad = styled.div`
   width: 100%;
@@ -26,7 +27,6 @@ const TagItem = styled.li`
   padding: 5px 13px;
   border: 1px solid ${mainGreen};
   border-radius: 15px;
-  color: ${mainGreen};
   white-space: nowrap;
   margin: 0 4px 4px 0;
 `;
@@ -39,12 +39,14 @@ const TextArea = styled.textarea`
   padding: 23px 20px;
   resize: none;
   font-size: 20px;
-  color: ${fontNormal};
+  color: ${mainBlack};
 
   ::placeholder {
     color: ${fontNormal};
   }
 `;
+
+const RemoveBtn = styled.button``;
 
 const PostAddPage = () => {
   const [tags, setTags] = useState([]);
@@ -53,6 +55,12 @@ const PostAddPage = () => {
     setTags((state) => [...state, value]);
     console.log(value);
   };
+
+  const onRemoveTag = (index) => {
+    const updateTags = tags.filter((_, itemIndex) => itemIndex !== index);
+    setTags(updateTags);
+  };
+
   return (
     <>
       <ImageLoad></ImageLoad>
@@ -77,7 +85,7 @@ const PostAddPage = () => {
         {tags.map((tag, index) => (
           <TagItem key={index}>
             {tag}
-            <button>x</button>
+            <RemoveBtn onClick={() => onRemoveTag(index)}>x</RemoveBtn>
           </TagItem>
         ))}
       </TagList>

--- a/src/stories/components/UploadImage.stories.jsx
+++ b/src/stories/components/UploadImage.stories.jsx
@@ -1,0 +1,11 @@
+import UploadImage from 'components/UploadImage';
+
+export default {
+  title: 'Component/UploadImage',
+  component: UploadImage,
+  argTypes: {},
+};
+
+export const Default = (args) => {
+  return <UploadImage {...args}></UploadImage>;
+};


### PR DESCRIPTION
## PR 템플릿
## ✅ 이슈 번호

## 📌 기능 설명 <!-- 기능을 대략적으로 설명해주세요 -->

- 이미지를 업로드하고 태그 입력이 가능합니다.
- 태그의 input에 1~6글자, 특수문자, 띄어쓰기를 제한하였습니다.
- 정보수정 페이지에서도 사용할 것을 고려하여 useValidHook을 만들었습니다.
- 이미지, 태그, 성장 글을 작성하고 게시물 등록 버튼을 누르면 게시물이 업로드됩니다.

서버 요청을 위한 테스트 코드가 남아있습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 요구 사항과 실제 구현 내용을 작성해 주세요 -->

## 구현 결과

**태그입력 부분**

![image](https://user-images.githubusercontent.com/81489300/173665103-dd597641-0c11-4023-bd92-2fdccf146bad.png)

**게시물 등록 부분**

![image](https://user-images.githubusercontent.com/81489300/173665269-bf832df4-d05b-4aad-b3eb-c1eb0ba01202.png)
