### PR TITLE
feat: Page wrapper 추가

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -3,6 +3,7 @@ import Icon from 'components/basic/Icon';
 import theme from 'styles/theme';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 
+const { headerHeight } = theme.value;
 const { borderLight, mainWhite } = theme.color;
 
 const HeaderContainer = styled.header`
@@ -10,6 +11,7 @@ const HeaderContainer = styled.header`
   justify-content: space-between;
   align-items: center;
   width: 100%;
+  height: ${headerHeight};
   max-width: 500px;
   padding: 30px 20px;
   border-bottom: 1px solid ${borderLight};

--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -2,13 +2,15 @@ import styled from '@emotion/styled';
 import Icon from 'components/basic/Icon';
 import theme from 'styles/theme';
 import { Link } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
-import { useParams, useLocation } from 'react-router-dom';
-
+const { navHeight } = theme.value;
 const { mainWhite, borderLight } = theme.color;
+
 const NavContainer = styled.div`
   position: fixed;
   width: 100%;
+  height: ${navHeight};
   max-width: 500px;
   margin: 0 auto;
   left: 0;
@@ -21,11 +23,14 @@ const NavContainer = styled.div`
 
 const NavList = styled.ul`
   display: flex;
+  height: 100%;
 
   a {
-    display: block;
     width: 100%;
-    padding: 30px 0;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 `;
 

--- a/src/components/UploadImage/index.jsx
+++ b/src/components/UploadImage/index.jsx
@@ -5,6 +5,11 @@ import theme from 'styles/theme';
 
 const { backgroundGreen } = theme.color;
 
+const ImageWrapper = styled.div`
+  margin-left: -20px;
+  margin-right: -20px;
+`;
+
 const ImageLoad = styled.div`
   width: 100%;
   background-color: ${backgroundGreen};
@@ -47,7 +52,7 @@ const UploadImage = ({ onChange, defaultImage = null, ...props }) => {
   };
 
   return (
-    <div>
+    <ImageWrapper>
       <ImageLoad
         onClick={() => fileInputRef.current.click()}
         style={{ ...props.style }}
@@ -60,7 +65,7 @@ const UploadImage = ({ onChange, defaultImage = null, ...props }) => {
         id="file"
         onChange={handleFileChange}
       />
-    </div>
+    </ImageWrapper>
   );
 };
 

--- a/src/components/basic/pageWrapper/index.js
+++ b/src/components/basic/pageWrapper/index.js
@@ -1,0 +1,16 @@
+import theme from 'styles/theme';
+
+const { headerHeight, navHeight, pagePadding } = theme.value;
+
+const PageWrapper = ({ children, header, nav }) => {
+  const wrapperStyle = {
+    paddingTop: header ? headerHeight : 0,
+    paddingLeft: pagePadding,
+    paddingRight: pagePadding,
+    paddingBottom: nav ? navHeight : 0,
+  };
+
+  return <div style={{ ...wrapperStyle }}>{children}</div>;
+};
+
+export default PageWrapper;

--- a/src/pages/PostAddPage/index.jsx
+++ b/src/pages/PostAddPage/index.jsx
@@ -6,12 +6,9 @@ import Button from 'components/basic/Button';
 import UploadImage from 'components/UploadImage';
 import TagAddForm from 'components/TagAddForm';
 import theme from 'styles/theme';
+import PageWrapper from 'components/basic/pageWrapper';
 
 const { fontNormal, borderNormal, mainBlack } = theme.color;
-
-const Wrapper = styled.div`
-  padding: 0 20px;
-`;
 
 const TextArea = styled.textarea`
   margin-top: 20px;
@@ -92,8 +89,9 @@ const PostAddPage = () => {
 
   return (
     <>
-      <UploadImage onChange={onFileChange} />
-      <Wrapper>
+      <PageWrapper header>
+        <UploadImage onChange={onFileChange} />
+
         <TagAddForm onAddTag={onAddTag} onRemoveTag={onRemoveTag} tags={tags} />
         <TextArea
           onChange={(e) => {
@@ -102,13 +100,14 @@ const PostAddPage = () => {
           placeholder="내 식물의 성장 글을 작성해주세요."
           rows={10}
         ></TextArea>
-      </Wrapper>
-      <Button
-        style={{ marginTop: '15px', marginBottom: '15px' }}
-        onClick={onClickAddBtn}
-      >
-        게시물 등록
-      </Button>
+
+        <Button
+          style={{ marginTop: '15px', marginBottom: '15px' }}
+          onClick={onClickAddBtn}
+        >
+          게시물 등록
+        </Button>
+      </PageWrapper>
     </>
   );
 };

--- a/src/pages/SearchPage/index.jsx
+++ b/src/pages/SearchPage/index.jsx
@@ -12,6 +12,7 @@ import Text from 'components/basic/Text';
 import { IMAGE_URLS } from 'utils/constants/images';
 import Button from 'components/basic/Button';
 import { Link } from 'react-router-dom';
+import PageWrapper from 'components/basic/pageWrapper';
 
 const TAG = 'tag';
 const USER = 'user';
@@ -95,57 +96,57 @@ const SearchPage = () => {
   }, [currentTab]);
 
   return (
-    <Wrapper>
+    <PageWrapper header nav>
       <InputForm
         name="search"
         placeholder="검색어를 입력해주세요."
         onSubmit={onSubmit}
+        style={{ marginTop: '20px' }}
       />
-      <div>
-        <Tab onActive={onActive}>
-          <Tab.Item title="태그" index={TAG}>
-            <PostImageList>
-              {searchData.tag &&
-                searchData.tag.map((post) => {
-                  return (
-                    <Link to={`post/detail/${post._id}`} key={post._id}>
-                      <Image
-                        lazy
-                        width="100%"
-                        block
-                        threshold={0.5}
-                        src={post.image}
-                      />
-                    </Link>
-                  );
-                })}
-            </PostImageList>
-          </Tab.Item>
-          <Tab.Item title="계정" index={USER}>
-            {searchData.user &&
-              searchData.user.map((data) => {
+
+      <Tab onActive={onActive}>
+        <Tab.Item title="태그" index={TAG}>
+          <PostImageList>
+            {searchData.tag &&
+              searchData.tag.map((post) => {
                 return (
-                  <ProfileContainer key={data._id}>
-                    <Profile>
-                      <Avatar size={60} src={IMAGE_URLS.PROFILE_iMG} />
-                      <Nickname fontSize={18}>{data.fullName}</Nickname>
-                    </Profile>
-                    <FollowBtn
-                      width={100}
-                      height={30}
-                      borderRadius={10}
-                      fontSize="16px"
-                      style={{ flexShrink: 0 }}
-                    >
-                      팔로우
-                    </FollowBtn>
-                  </ProfileContainer>
+                  <Link to={`post/detail/${post._id}`} key={post._id}>
+                    <Image
+                      lazy
+                      width="100%"
+                      block
+                      threshold={0.5}
+                      src={post.image}
+                    />
+                  </Link>
                 );
               })}
-          </Tab.Item>
-        </Tab>
-      </div>
-    </Wrapper>
+          </PostImageList>
+        </Tab.Item>
+        <Tab.Item title="계정" index={USER}>
+          {searchData.user &&
+            searchData.user.map((data) => {
+              return (
+                <ProfileContainer key={data._id}>
+                  <Profile>
+                    <Avatar size={60} src={IMAGE_URLS.PROFILE_iMG} />
+                    <Nickname fontSize={18}>{data.fullName}</Nickname>
+                  </Profile>
+                  <FollowBtn
+                    width={100}
+                    height={30}
+                    borderRadius={10}
+                    fontSize="16px"
+                    style={{ flexShrink: 0 }}
+                  >
+                    팔로우
+                  </FollowBtn>
+                </ProfileContainer>
+              );
+            })}
+        </Tab.Item>
+      </Tab>
+    </PageWrapper>
   );
 };
 

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -12,4 +12,9 @@ export default {
     backgroundLight: '#F8F8F8',
     mainWhite: '#FFFFFF',
   },
+  value: {
+    headerHeight: '80px',
+    navHeight: '75px',
+    pagePadding: '20px',
+  },
 };

--- a/src/template/DefaultTemplate.jsx
+++ b/src/template/DefaultTemplate.jsx
@@ -38,6 +38,11 @@ const Container = styled.div`
   height: ${({ height }) => `${height}`}px;
   background-color: ${({ theme }) => theme.color.mainWhite};
 
+  -ms-overflow-style: none;
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
   @media screen and (max-width: 500px) {
     width: 100%;
   }


### PR DESCRIPTION
## PR 템플릿
## ✅ 이슈 번호

## 📌 기능 설명 <!-- 기능을 대략적으로 설명해주세요 -->

- Page 내부에 적용할 Wrapper를 구현하였습니다.
- header, nav 속성을 통해 해당 page에 높이에 맞는 padding을 추가할 수 있습니다.
![image](https://user-images.githubusercontent.com/81489300/173703634-8ccad751-e2bd-42e7-a1fc-3e9ed57f9daa.png)
 => 해당 페이지에 header와 navigation이 모두 있는 경우.

- 기본 페이지들에 적용되어있는 padding left, right 값이 적용되어 있습니다 (20px)

- header, navigation의 height는 변수로 처리하여 값이 변경되면 wrapper의 값도 변경됩니다.
![image](https://user-images.githubusercontent.com/81489300/173703899-2504a27a-099d-4ab7-9753-3067711d5275.png)

- header와 navigation의 높이가 높아서 콘텐츠가 잘 보이지 않는다는 의견이 있었어서
높이를 변경했습니다. (90px -> 75px)

