### PR TITLE
feat: 태그 검색 페이지(SearchTagPage) 구현

### DIFF
--- a/src/components/TagSearchResult/index.jsx
+++ b/src/components/TagSearchResult/index.jsx
@@ -1,0 +1,23 @@
+import PostImageList from 'components/PostImageList';
+import { Link } from 'react-router-dom';
+import Image from 'components/basic/Image';
+import PropTypes from 'prop-types';
+
+const TagSearchResult = ({ posts }) => {
+  return (
+    <PostImageList>
+      {posts &&
+        posts.map((post) => (
+          <Link to={`/post/detail/${post._id}`} key={post._id}>
+            <Image lazy width="100%" block threshold={0.5} src={post.image} />
+          </Link>
+        ))}
+    </PostImageList>
+  );
+};
+
+TagSearchResult.propTypes = {
+  posts: PropTypes.array,
+};
+
+export default TagSearchResult;

--- a/src/components/UserSearchResult/index.jsx
+++ b/src/components/UserSearchResult/index.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import Avatar from 'components/basic/Avatar';
+import Button from 'components/basic/Button';
+import { IMAGE_URLS } from 'utils/constants/images';
+import PropTypes from 'prop-types';
+
+const ProfileContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 15px 20px;
+`;
+const Profile = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 15px 20px;
+`;
+
+const Nickname = styled(Text)`
+  margin-left: 20px;
+`;
+
+const FollowBtn = styled(Button)``;
+
+const UserSearchResult = ({ users }) => {
+  return (
+    <>
+      {users.map((user) => {
+        return (
+          <ProfileContainer key={user._id}>
+            <Profile>
+              <Avatar size={60} src={IMAGE_URLS.PROFILE_iMG} />
+              <Nickname fontSize={18}>{user.fullName}</Nickname>
+            </Profile>
+            <FollowBtn
+              width={100}
+              height={30}
+              borderRadius={10}
+              fontSize="16px"
+              style={{ flexShrink: 0 }}
+            >
+              팔로우
+            </FollowBtn>
+          </ProfileContainer>
+        );
+      })}
+    </>
+  );
+};
+
+UserSearchResult.propTypes = {
+  posts: PropTypes.array,
+};
+
+export default UserSearchResult;

--- a/src/pages/SearchPage/index.jsx
+++ b/src/pages/SearchPage/index.jsx
@@ -110,7 +110,7 @@ const SearchPage = () => {
             {searchData.tag &&
               searchData.tag.map((post) => {
                 return (
-                  <Link to={`post/detail/${post._id}`} key={post._id}>
+                  <Link to={`/post/detail/${post._id}`} key={post._id}>
                     <Image
                       lazy
                       width="100%"

--- a/src/pages/SearchPage/index.jsx
+++ b/src/pages/SearchPage/index.jsx
@@ -13,29 +13,11 @@ import { IMAGE_URLS } from 'utils/constants/images';
 import Button from 'components/basic/Button';
 import { Link } from 'react-router-dom';
 import PageWrapper from 'components/basic/pageWrapper';
+import TagSearchResult from 'components/TagSearchResult';
+import UserSearchResult from 'components/UserSearchResult';
 
 const TAG = 'tag';
 const USER = 'user';
-
-const Wrapper = styled.div`
-  padding: 20px;
-`;
-const ProfileContainer = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 15px 20px;
-`;
-const Profile = styled.div`
-  display: flex;
-  align-items: center;
-  padding: 15px 20px;
-`;
-const Nickname = styled(Text)`
-  margin-left: 20px;
-`;
-
-const FollowBtn = styled(Button)``;
 
 const getSearchTag = async (keyword) => {
   const result = await axios.get(`/search/all/%23${keyword}`);
@@ -57,7 +39,6 @@ const getSearchUser = async (keyword) => {
 
 const SearchPage = () => {
   const [currentTab, setCurrentTab] = useState('tag');
-
   const [searchData, setSearchData] = useState({
     keyword: '',
     [TAG]: null,
@@ -69,6 +50,7 @@ const SearchPage = () => {
       if (currentTab === TAG) {
         const result = await getSearchTag(keyword);
         setSearchData((state) => ({ ...state, tag: result, keyword }));
+        console.log(result);
       }
 
       if (currentTab === USER) {
@@ -106,44 +88,10 @@ const SearchPage = () => {
 
       <Tab onActive={onActive}>
         <Tab.Item title="태그" index={TAG}>
-          <PostImageList>
-            {searchData.tag &&
-              searchData.tag.map((post) => {
-                return (
-                  <Link to={`/post/detail/${post._id}`} key={post._id}>
-                    <Image
-                      lazy
-                      width="100%"
-                      block
-                      threshold={0.5}
-                      src={post.image}
-                    />
-                  </Link>
-                );
-              })}
-          </PostImageList>
+          <TagSearchResult posts={searchData.tag} />
         </Tab.Item>
         <Tab.Item title="계정" index={USER}>
-          {searchData.user &&
-            searchData.user.map((data) => {
-              return (
-                <ProfileContainer key={data._id}>
-                  <Profile>
-                    <Avatar size={60} src={IMAGE_URLS.PROFILE_iMG} />
-                    <Nickname fontSize={18}>{data.fullName}</Nickname>
-                  </Profile>
-                  <FollowBtn
-                    width={100}
-                    height={30}
-                    borderRadius={10}
-                    fontSize="16px"
-                    style={{ flexShrink: 0 }}
-                  >
-                    팔로우
-                  </FollowBtn>
-                </ProfileContainer>
-              );
-            })}
+          <UserSearchResult users={searchData.user} />
         </Tab.Item>
       </Tab>
     </PageWrapper>

--- a/src/pages/SearchTagPage/index.jsx
+++ b/src/pages/SearchTagPage/index.jsx
@@ -1,5 +1,60 @@
+import PostImageList from 'components/PostImageList';
+import Image from 'components/basic/Image';
+import { Link } from 'react-router-dom';
+import { useCallback, useEffect, useState } from 'react';
+import PageWrapper from 'components/basic/pageWrapper';
+import styled from '@emotion/styled';
+import { searchTag } from 'utils/apis/postApi';
+import axios from 'axios';
+
+const Keyword = styled.h3`
+  display: block;
+  text-align: center;
+  margin: 40px 0 30px;
+  font-size: 30px;
+`;
+
+/*
+  TODO:
+  1. 태그 클릭 시 넘어온 keyword로 검색되게 교체
+  2. 테스트 코드들 정리하고 코드 간소화 필요
+  3. 정사각형의 이미지가 아니면 postList에서 짤려보이는데 이 부분 처리 필요
+  4. 태그 클릭하여 넘어올 때 클릭한 태그의 키워드를 url에 담아주면 좋을 듯
+*/
+
 const SearchTagPage = () => {
-  return <div>SearchTagPage</div>;
+  const searchKeyword = '선인장'; // 임시 키워드
+  const [posts, setPosts] = useState();
+
+  const getTagPosts = async (keyword) => {
+    const result = await axios.get(`/search/all/%23${keyword}`);
+    return result.data;
+  };
+
+  const loadPosts = useCallback(async () => {
+    // const test = await searchTag(searchKeyword); // 이렇게 요청하면 왜인지는 모르겠지만 안된다. 확인 필요
+    const updatePost = await getTagPosts(searchKeyword);
+    setPosts(updatePost);
+  }, []);
+
+  useEffect(() => {
+    loadPosts();
+    console.log('Loaded Post');
+  }, [loadPosts]);
+
+  return (
+    <PageWrapper header>
+      <Keyword onClick={loadPosts}>#{searchKeyword}</Keyword>
+      <PostImageList>
+        {posts &&
+          posts.map((post) => (
+            <Link to={`/post/detail/${post._id}`} key={post._id}>
+              <Image lazy width="100%" block threshold={0.5} src={post.image} />
+            </Link>
+          ))}
+      </PostImageList>
+    </PageWrapper>
+  );
 };
 
 export default SearchTagPage;

--- a/src/pages/SearchTagPage/index.jsx
+++ b/src/pages/SearchTagPage/index.jsx
@@ -1,13 +1,11 @@
-import PostImageList from 'components/PostImageList';
-import Image from 'components/basic/Image';
-import { Link } from 'react-router-dom';
+import axios from 'axios';
+import styled from '@emotion/styled';
 import { useCallback, useEffect, useState } from 'react';
 import PageWrapper from 'components/basic/pageWrapper';
-import styled from '@emotion/styled';
+import TagSearchResult from 'components/TagSearchResult';
 import { searchTag } from 'utils/apis/postApi';
-import axios from 'axios';
 
-const Keyword = styled.h3`
+const Header = styled.h3`
   display: block;
   text-align: center;
   margin: 40px 0 30px;
@@ -44,15 +42,8 @@ const SearchTagPage = () => {
 
   return (
     <PageWrapper header>
-      <Keyword onClick={loadPosts}>#{searchKeyword}</Keyword>
-      <PostImageList>
-        {posts &&
-          posts.map((post) => (
-            <Link to={`/post/detail/${post._id}`} key={post._id}>
-              <Image lazy width="100%" block threshold={0.5} src={post.image} />
-            </Link>
-          ))}
-      </PostImageList>
+      <Header onClick={loadPosts}>#{searchKeyword}</Header>
+      <TagSearchResult posts={posts} />
     </PageWrapper>
   );
 };

--- a/src/utils/apis/postApi.js
+++ b/src/utils/apis/postApi.js
@@ -56,7 +56,9 @@ export const getPostData = (postId) => {
 export const addPost = (token, data) => {
   const submitData = { ...data, meta: JSON.stringify(data.meta) };
   const formData = new FormData();
-  Object.keys(submitData).forEach((key) => formData.append(key, submitData[key]));
+  Object.keys(submitData).forEach((key) =>
+    formData.append(key, submitData[key]),
+  );
   formData.append('channelId', process.env.REACT_APP_CHANNEL_ID_TOTAL);
 
   return request({
@@ -77,7 +79,9 @@ export const addPost = (token, data) => {
 export const updatePost = (token, data) => {
   const submitData = { ...data, meta: JSON.stringify(data.meta) };
   const formData = new FormData();
-  Object.keys(submitData).forEach((key) => formData.append(key, submitData[key]));
+  Object.keys(submitData).forEach((key) =>
+    formData.append(key, submitData[key]),
+  );
   formData.append('channelId', process.env.REACT_APP_CHANNEL_ID_TOTAL);
 
   return request({
@@ -173,5 +177,23 @@ export const deleteComment = (token, postId) => {
     data: {
       id: postId,
     },
+  });
+};
+
+/* 
+  특정 포스트를 검색한다.
+*/
+
+export const searchTag = (keyword) => {
+  return request({
+    method: API_METHOD.GET,
+    url: `/search/all/%23${keyword}`,
+  });
+};
+
+export const searchUser = (keyword) => {
+  return request({
+    method: API_METHOD.GET,
+    url: `/search/users/${keyword}`,
   });
 };


### PR DESCRIPTION
## PR 템플릿

## 📌 기능 설명 <!-- 기능을 대략적으로 설명해주세요 -->

- 게시물 목록, 게시물 상세보기의 태그버튼을 클릭시 진입되는 페이지입니다.
- 검색페이지와 다르게 클릭한 태그의 검색 결과만 볼 수 있습니다.
- 태그 클릭 시 해당 태그 명을 전달해주어야하기 때문에 일단 임시 keyword를 넣어놓은 상태입니다.
![image](https://user-images.githubusercontent.com/81489300/173789060-3f87e7b1-95a3-4bf5-942f-209f32bd2e4c.png)


## 구현 결과
![image](https://user-images.githubusercontent.com/81489300/173788853-173e64b4-0cd8-474a-8948-046dec3f4a22.png)
