### PR TITLE
refactor: Image 속성값 height 추가 및 mode 기본 cover로 받도록 수정 (#82)

### DIFF
--- a/src/components/basic/Image/index.jsx
+++ b/src/components/basic/Image/index.jsx
@@ -22,7 +22,7 @@ const Image = ({
   width,
   height,
   alt,
-  mode,
+  mode = 'cover',
   ...props
 }) => {
   const [loaded, setLoaded] = useState(false);
@@ -31,7 +31,6 @@ const Image = ({
   const imageStyle = {
     display: block ? 'block' : undefined,
     width,
-    height,
     objectFit: mode,
   };
 
@@ -44,11 +43,9 @@ const Image = ({
     const handleLoadImage = () => setLoaded(true);
 
     const imgElement = imgRef.current;
-    imgElement &&
-      imgElement.addEventListener(LOAD_IMG_EVENT_TYPE, handleLoadImage);
+    imgElement && imgElement.addEventListener(LOAD_IMG_EVENT_TYPE, handleLoadImage);
     return () => {
-      imgElement &&
-        imgElement.removeEventListener(LOAD_IMG_EVENT_TYPE, handleLoadImage);
+      imgElement && imgElement.removeEventListener(LOAD_IMG_EVENT_TYPE, handleLoadImage);
     };
   }, [lazy]);
 
@@ -65,6 +62,8 @@ const Image = ({
       ref={imgRef}
       src={loaded ? src : placeholder}
       alt={alt}
+      width={width}
+      height={height}
       style={{ ...props.style, ...imageStyle }}
     />
   );


### PR DESCRIPTION

## ✅ 이슈 번호
#82
## 📌 기능 설명 

Image 태그의 인라인 스타일 height가 적용되지 않던 문제 해결

## 👩‍💻 요구 사항과 구현 내용

1. 인라인스타일로 height가 작동하지 않아서 속성값을 따로 받도록 수정했습니다. 

```js
<Image lazy width="100%" **height="100%"** block threshold={0.5} src={post.image} />
```
2. object-fit을 결정하는 mode속성의 경우 기본값이 없었는데 cover로 바꿔줬습니다. 


## 구현 결과

![image](https://user-images.githubusercontent.com/79133602/173998849-3f8affa6-2225-40da-b720-52dc04fff4b4.png)


