### PR TITLE
refactor: PageWrapper 내부에 Header, Navigation 추가

### DIFF
--- a/src/components/FixedContainer/index.jsx
+++ b/src/components/FixedContainer/index.jsx
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled';
+import theme from 'styles/theme';
+
+const { mainWhite } = theme.color;
+
+const Fixed = styled.div`
+  position: fixed;
+  max-width: 500px;
+  margin: 0 auto;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  background-color: ${mainWhite};
+`;
+
+const FixedContainer = ({ children, width, height, top, bottom, ...props }) => {
+  const fixedStyle = {
+    width,
+    height,
+    top: top && 0,
+    bottom: bottom && 0,
+  };
+
+  return (
+    <Fixed {...props} style={{ ...fixedStyle, ...props.style }}>
+      {children}
+    </Fixed>
+  );
+};
+
+export default FixedContainer;

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import Icon from 'components/basic/Icon';
 import theme from 'styles/theme';
-import { Link, useNavigate, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 const { headerHeight } = theme.value;
 const { borderLight, mainWhite } = theme.color;
@@ -32,28 +32,12 @@ const InnerRight = styled.div`
 `;
 
 export const Header = () => {
-  const navigate = useNavigate();
-
-  const { pathname } = useLocation();
-
-  const hidePrev = ['/', '/user/mypage', '/search', '/post/detail'];
-  const hideHeader = ['/login', '/join'];
-  const onClickPrev = () => {
-    navigate(-1);
-  };
-
-  if (hideHeader.includes(pathname)) {
-    return;
-  }
-
   return (
     <HeaderContainer>
       <InnerLeft>
-        {!hidePrev.includes(pathname) && (
-          <button onClick={onClickPrev}>
-            <Icon name="ARROW_LEFT" size={20} />
-          </button>
-        )}
+        <button onClick={onClickPrev}>
+          <Icon name="ARROW_LEFT" size={20} />
+        </button>
       </InnerLeft>
       <InnerRight>
         <Link to="/notification">

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -39,7 +39,7 @@ const InnerRight = styled.div`
   }
 `;
 
-export const Header = ({ prev, title, complete, onComplete }) => {
+export const Header = ({ prev, title, info, complete, onComplete }) => {
   const navigate = useNavigate();
   const {
     currentUser: { notifications },
@@ -56,15 +56,13 @@ export const Header = ({ prev, title, complete, onComplete }) => {
       {title && <Title>{title}</Title>}
 
       <InnerRight>
-        {!title & !complete ? (
+        {info && (
           <>
             <Badge isShow={notifications?.seen}>
               <Icon.Link to="/notification" name="NOTIFICATION" size={30} />
             </Badge>
             <Icon.Link to="/user/myinfo" name="MY_INFO" size={30} />
           </>
-        ) : (
-          ''
         )}
         {complete && (
           <button onClick={onComplete}>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -23,16 +23,26 @@ const HeaderContainer = styled.header`
   z-index: 100;
   background-color: ${mainWhite};
 `;
+const Title = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;
 
 const InnerLeft = styled.div``;
 const InnerRight = styled.div`
+  display: flex;
+  align-items: center;
+
   a:not(:first-of-type) {
     margin-left: 20px;
   }
 `;
 
-export const Header = () => {
+export const Header = ({ prev, title }) => {
   const navigate = useNavigate();
+
   const onClickPrev = () => {
     navigate(-1);
   };
@@ -40,17 +50,12 @@ export const Header = () => {
   return (
     <HeaderContainer>
       <InnerLeft>
-        <button onClick={onClickPrev}>
-          <Icon name="ARROW_LEFT" size={20} />
-        </button>
+        {prev && <Icon.Button name="ARROW_LEFT" size={20} onClick={onClickPrev} />}
       </InnerLeft>
+      <Title>{title}</Title>
       <InnerRight>
-        <Link to="/notification">
-          <Icon name="NOTIFICATION" size={30} />
-        </Link>
-        <Link to="/user/myinfo">
-          <Icon name="MY_INFO" size={30} />
-        </Link>
+        <Icon.Link to="/notification" name="NOTIFICATION" size={30} />
+        <Icon.Link to="/user/myinfo" name="MY_INFO" size={30} />
       </InnerRight>
     </HeaderContainer>
   );

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,61 +1,76 @@
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
+import { useUserContext } from 'contexts/UserContext';
+import FixedContainer from 'components/FixedContainer';
+import Badge from 'components/basic/Badge';
 import Icon from 'components/basic/Icon';
+import Text from 'components/basic/Text';
 import theme from 'styles/theme';
-import { Link, useNavigate } from 'react-router-dom';
 
-const { headerHeight } = theme.value;
-const { borderLight, mainWhite } = theme.color;
+const { headerHeight, pagePadding } = theme.value;
+const { borderLight } = theme.color;
 
-const HeaderContainer = styled.header`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-  height: ${headerHeight};
-  max-width: 500px;
-  padding: 30px 20px;
+const HeaderContainer = styled(FixedContainer)`
   border-bottom: 1px solid ${borderLight};
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  margin: 0 auto;
-  z-index: 100;
-  background-color: ${mainWhite};
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 ${pagePadding};
 `;
+
 const Title = styled.div`
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  font-size: 20px;
+  font-weight: 500;
 `;
 
-const InnerLeft = styled.div``;
 const InnerRight = styled.div`
+  position: absolute;
+  top: 50%;
+  right: ${pagePadding};
+  transform: translateY(-50%);
   display: flex;
-  align-items: center;
 
-  a:not(:first-of-type) {
+  & > * {
     margin-left: 20px;
   }
 `;
 
-export const Header = ({ prev, title }) => {
+export const Header = ({ prev, title, complete, onComplete }) => {
   const navigate = useNavigate();
+  const {
+    currentUser: { notifications },
+  } = useUserContext();
 
   const onClickPrev = () => {
     navigate(-1);
   };
 
   return (
-    <HeaderContainer>
-      <InnerLeft>
-        {prev && <Icon.Button name="ARROW_LEFT" size={20} onClick={onClickPrev} />}
-      </InnerLeft>
-      <Title>{title}</Title>
+    <HeaderContainer top height={headerHeight}>
+      <div>{prev && <Icon.Button name="ARROW_LEFT" size={20} onClick={onClickPrev} />}</div>
+
+      {title && <Title>{title}</Title>}
+
       <InnerRight>
-        <Icon.Link to="/notification" name="NOTIFICATION" size={30} />
-        <Icon.Link to="/user/myinfo" name="MY_INFO" size={30} />
+        {!title && (
+          <>
+            <Badge isShow={notifications?.seen}>
+              <Icon.Link to="/notification" name="NOTIFICATION" size={30} />
+            </Badge>
+            <Icon.Link to="/user/myinfo" name="MY_INFO" size={30} />
+          </>
+        )}
+        {complete && (
+          <button onClick={onComplete}>
+            <Text fontSize={20} fontWeight={500}>
+              완료
+            </Text>
+          </button>
+        )}
       </InnerRight>
     </HeaderContainer>
   );

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -56,13 +56,15 @@ export const Header = ({ prev, title, complete, onComplete }) => {
       {title && <Title>{title}</Title>}
 
       <InnerRight>
-        {!title && (
+        {!title & !complete ? (
           <>
             <Badge isShow={notifications?.seen}>
               <Icon.Link to="/notification" name="NOTIFICATION" size={30} />
             </Badge>
             <Icon.Link to="/user/myinfo" name="MY_INFO" size={30} />
           </>
+        ) : (
+          ''
         )}
         {complete && (
           <button onClick={onComplete}>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import Icon from 'components/basic/Icon';
 import theme from 'styles/theme';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 const { headerHeight } = theme.value;
 const { borderLight, mainWhite } = theme.color;
@@ -32,6 +32,11 @@ const InnerRight = styled.div`
 `;
 
 export const Header = () => {
+  const navigate = useNavigate();
+  const onClickPrev = () => {
+    navigate(-1);
+  };
+
   return (
     <HeaderContainer>
       <InnerLeft>

--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -32,39 +32,31 @@ const NavItem = styled.li`
   cursor: pointer;
 `;
 
-export const Navigation = ({ pathname }) => {
+export const Navigation = () => {
+  const { pathname } = useLocation();
+
   return (
     <NavContainer bottom height={navHeight}>
       <NavList>
         <NavItem>
-          <Link to="/">
-            {pathname === '/' ? (
-              <Icon name="HOME_ACTIVE" size={27} />
-            ) : (
-              <Icon name="HOME" size={27} />
-            )}
-          </Link>
+          <Icon.Link to="/" name={pathname === '/' ? 'HOME_ACTIVE' : 'HOME'} size={27} />
         </NavItem>
         <NavItem>
           <Icon.Link to="/post/create" name="ADD_POST" size={27} />
         </NavItem>
         <NavItem>
-          <Link to="/search">
-            {pathname === '/search' ? (
-              <Icon name="SEARCH_ACTIVE" size={27} />
-            ) : (
-              <Icon name="SEARCH" size={27} />
-            )}
-          </Link>
+          <Icon.Link
+            to="/search"
+            name={pathname === '/search' ? 'SEARCH_ACTIVE' : 'SEARCH'}
+            size={27}
+          />
         </NavItem>
         <NavItem>
-          <Link to="/user/mypage">
-            {pathname === '/user/mypage' ? (
-              <Icon name="MY_PAGE_ACTIVE" size={27} />
-            ) : (
-              <Icon name="MY_PAGE" size={27} />
-            )}
-          </Link>
+          <Icon.Link
+            to="/user/mypage"
+            name={pathname === '/user/mypage' ? 'MY_PAGE_ACTIVE' : 'MY_PAGE'}
+            size={27}
+          />
         </NavItem>
       </NavList>
     </NavContainer>

--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -40,15 +40,7 @@ const NavItem = styled.li`
   cursor: pointer;
 `;
 
-export const Navigation = () => {
-  const { pathname } = useLocation();
-
-  const showTab = ['/', '/user/mypage', '/search', '/post/detail'];
-
-  if (!showTab.includes(pathname)) {
-    return;
-  }
-
+export const Navigation = ({ pathname }) => {
   return (
     <NavContainer>
       <NavList>

--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -3,22 +3,14 @@ import Icon from 'components/basic/Icon';
 import theme from 'styles/theme';
 import { Link } from 'react-router-dom';
 import { useLocation } from 'react-router-dom';
+import FixedContainer from 'components/FixedContainer';
 
 const { navHeight } = theme.value;
 const { mainWhite, borderLight } = theme.color;
 
-const NavContainer = styled.div`
-  position: fixed;
-  width: 100%;
-  height: ${navHeight};
-  max-width: 500px;
-  margin: 0 auto;
-  left: 0;
-  right: 0;
-  bottom: 0;
+const NavContainer = styled(FixedContainer)`
   border-top: 1px solid ${borderLight};
   background-color: ${mainWhite};
-  z-index: 100;
 `;
 
 const NavList = styled.ul`
@@ -42,7 +34,7 @@ const NavItem = styled.li`
 
 export const Navigation = ({ pathname }) => {
   return (
-    <NavContainer>
+    <NavContainer bottom height={navHeight}>
       <NavList>
         <NavItem>
           <Link to="/">
@@ -54,9 +46,7 @@ export const Navigation = ({ pathname }) => {
           </Link>
         </NavItem>
         <NavItem>
-          <Link to="/post/create">
-            <Icon name="ADD_POST" size={27} />
-          </Link>
+          <Icon.Link to="/post/create" name="ADD_POST" size={27} />
         </NavItem>
         <NavItem>
           <Link to="/search">

--- a/src/components/basic/pageWrapper/index.js
+++ b/src/components/basic/pageWrapper/index.js
@@ -4,7 +4,7 @@ import theme from 'styles/theme';
 
 const { headerHeight, navHeight, pagePadding } = theme.value;
 
-const PageWrapper = ({ children, header, nav, prev }) => {
+const PageWrapper = ({ children, title, header, nav, prev, complete, onComplete, ...props }) => {
   const wrapperStyle = {
     paddingTop: header ? headerHeight : 0,
     paddingLeft: pagePadding,
@@ -14,8 +14,8 @@ const PageWrapper = ({ children, header, nav, prev }) => {
 
   return (
     <div>
-      {header && <Header prev={prev} />}
-      <div style={{ ...wrapperStyle }}> {children}</div>
+      {header && <Header prev={prev} title={title} complete={complete} onComplete={onComplete} />}
+      <div style={{ ...wrapperStyle, ...props.style }}> {children}</div>
       {nav && <Navigation />}
     </div>
   );

--- a/src/components/basic/pageWrapper/index.js
+++ b/src/components/basic/pageWrapper/index.js
@@ -13,10 +13,10 @@ const PageWrapper = ({ children, header, nav }) => {
   };
 
   return (
-    <div style={{ ...wrapperStyle }}>
-      <Header />
-      {children}
-      <Navigation />
+    <div>
+      {header && <Header />}
+      <div style={{ ...wrapperStyle }}> {children}</div>
+      {nav && <Navigation />}
     </div>
   );
 };

--- a/src/components/basic/pageWrapper/index.js
+++ b/src/components/basic/pageWrapper/index.js
@@ -4,7 +4,17 @@ import theme from 'styles/theme';
 
 const { headerHeight, navHeight, pagePadding } = theme.value;
 
-const PageWrapper = ({ children, title, header, nav, prev, complete, onComplete, ...props }) => {
+const PageWrapper = ({
+  children,
+  title,
+  header,
+  nav,
+  info,
+  prev,
+  complete,
+  onComplete,
+  ...props
+}) => {
   const wrapperStyle = {
     paddingTop: header ? headerHeight : 0,
     paddingLeft: pagePadding,
@@ -14,7 +24,9 @@ const PageWrapper = ({ children, title, header, nav, prev, complete, onComplete,
 
   return (
     <div>
-      {header && <Header prev={prev} title={title} complete={complete} onComplete={onComplete} />}
+      {header && (
+        <Header prev={prev} title={title} info={info} complete={complete} onComplete={onComplete} />
+      )}
       <div style={{ ...wrapperStyle, ...props.style }}> {children}</div>
       {nav && <Navigation />}
     </div>

--- a/src/components/basic/pageWrapper/index.js
+++ b/src/components/basic/pageWrapper/index.js
@@ -1,3 +1,5 @@
+import Header from 'components/Header/Header';
+import Navigation from 'components/Navigation';
 import theme from 'styles/theme';
 
 const { headerHeight, navHeight, pagePadding } = theme.value;
@@ -10,7 +12,13 @@ const PageWrapper = ({ children, header, nav }) => {
     paddingBottom: nav ? navHeight : 0,
   };
 
-  return <div style={{ ...wrapperStyle }}>{children}</div>;
+  return (
+    <div style={{ ...wrapperStyle }}>
+      <Header />
+      {children}
+      <Navigation />
+    </div>
+  );
 };
 
 export default PageWrapper;

--- a/src/components/basic/pageWrapper/index.js
+++ b/src/components/basic/pageWrapper/index.js
@@ -4,7 +4,7 @@ import theme from 'styles/theme';
 
 const { headerHeight, navHeight, pagePadding } = theme.value;
 
-const PageWrapper = ({ children, header, nav }) => {
+const PageWrapper = ({ children, header, nav, prev }) => {
   const wrapperStyle = {
     paddingTop: header ? headerHeight : 0,
     paddingLeft: pagePadding,
@@ -14,7 +14,7 @@ const PageWrapper = ({ children, header, nav }) => {
 
   return (
     <div>
-      {header && <Header />}
+      {header && <Header prev={prev} />}
       <div style={{ ...wrapperStyle }}> {children}</div>
       {nav && <Navigation />}
     </div>

--- a/src/pages/PostAddPage/index.jsx
+++ b/src/pages/PostAddPage/index.jsx
@@ -7,6 +7,7 @@ import UploadImage from 'components/UploadImage';
 import TagAddForm from 'components/TagAddForm';
 import theme from 'styles/theme';
 import PageWrapper from 'components/basic/pageWrapper';
+import FixedContainer from 'components/FixedContainer';
 
 const { fontNormal, borderNormal, mainBlack } = theme.color;
 
@@ -89,7 +90,7 @@ const PostAddPage = () => {
 
   return (
     <>
-      <PageWrapper header>
+      <PageWrapper title="게시물 등록" header prev style={{ paddingBottom: 100 }}>
         <UploadImage onChange={onFileChange} />
 
         <TagAddForm onAddTag={onAddTag} onRemoveTag={onRemoveTag} tags={tags} />
@@ -100,13 +101,11 @@ const PostAddPage = () => {
           placeholder="내 식물의 성장 글을 작성해주세요."
           rows={10}
         ></TextArea>
-
-        <Button
-          style={{ marginTop: '15px', marginBottom: '15px' }}
-          onClick={onClickAddBtn}
-        >
-          게시물 등록
-        </Button>
+        <FixedContainer bottom>
+          <Button style={{ marginTop: '15px', marginBottom: '15px' }} onClick={onClickAddBtn}>
+            게시물 등록
+          </Button>
+        </FixedContainer>
       </PageWrapper>
     </>
   );

--- a/src/pages/SearchPage/index.jsx
+++ b/src/pages/SearchPage/index.jsx
@@ -78,7 +78,7 @@ const SearchPage = () => {
   }, [currentTab]);
 
   return (
-    <PageWrapper header nav>
+    <PageWrapper header nav info>
       <InputForm
         name="search"
         placeholder="검색어를 입력해주세요."

--- a/src/pages/SearchTagPage/index.jsx
+++ b/src/pages/SearchTagPage/index.jsx
@@ -41,7 +41,7 @@ const SearchTagPage = () => {
   }, [loadPosts]);
 
   return (
-    <PageWrapper header>
+    <PageWrapper header prev>
       <Header onClick={loadPosts}>#{searchKeyword}</Header>
       <TagSearchResult posts={posts} />
     </PageWrapper>

--- a/src/pages/SearchTagPage/index.jsx
+++ b/src/pages/SearchTagPage/index.jsx
@@ -41,7 +41,7 @@ const SearchTagPage = () => {
   }, [loadPosts]);
 
   return (
-    <PageWrapper header prev>
+    <PageWrapper header prev info>
       <Header onClick={loadPosts}>#{searchKeyword}</Header>
       <TagSearchResult posts={posts} />
     </PageWrapper>

--- a/src/template/DefaultTemplate.jsx
+++ b/src/template/DefaultTemplate.jsx
@@ -1,6 +1,4 @@
 import styled from '@emotion/styled';
-import Header from 'components/Header/Header';
-import Navigation from 'components/Navigation';
 import { useEffect, useState } from 'react';
 
 const DefaultTemplate = ({ children }) => {
@@ -17,8 +15,6 @@ const DefaultTemplate = ({ children }) => {
 
   return (
     <Container id="default-template-container" height={height}>
-      <Header />
-      <Navigation />
       <StyledMain>{children}</StyledMain>
     </Container>
   );


### PR DESCRIPTION

## 📌 기능 설명 <!-- 기능을 대략적으로 설명해주세요 -->

- 내부 padding만 관리하던  PageWrapper 안에 Header와 Navigation을 넣었습니다.
- 기본적으로 아래와 같이 사용할 수 있습니다.
![image](https://user-images.githubusercontent.com/81489300/174129913-a0b3445f-5f8c-437f-855f-61e5ccabcc3f.png)
![image](https://user-images.githubusercontent.com/81489300/174130997-a2f0ff08-b96e-4187-8d7c-6da3e0ddf668.png)



- navigation은 props 하나로 처리가 가능하지만 Header는 각 페이지별로 나타나는 내용이 다르기 때문에
추가 구성이 필요합니다.
- PageWrapper의 props 구성은 아래와 같습니다.
![image](https://user-images.githubusercontent.com/81489300/174130877-4153234d-129d-4911-a938-4f9884f07c22.png)

## 사용예시
1. 뒤로가기 + title 사용 시 (+Navigation)
![image](https://user-images.githubusercontent.com/81489300/174130523-c5f5170d-7547-4b7d-bcf3-ec72b53c3e06.png)
![image](https://user-images.githubusercontent.com/81489300/174130213-d3387902-db3d-422b-92ee-8226302b7632.png)

2.  뒤로가기 + 완료버튼 사용 시 (Navigation X)
![image](https://user-images.githubusercontent.com/81489300/174136576-cfe834e3-b642-4297-a317-52fcb6ae173c.png)
![image](https://user-images.githubusercontent.com/81489300/174132979-7d62bd22-798f-4db8-8d8d-39ce17ad3fe2.png)

- complete부분은 props로 함수만 받으려고 생각했다가
명시적으로 작성하는 것으로 변경했습니다.


+ 추가로 SearchPage, SearchTagPage, PostAddPage에 적용했습니다.

- 다른 의견 있으시거나 추가/수정할 부분이 있다면 코멘트 부탁드립니다.
