### PR TITLE
feat: fullName, password validation 수정

### DIFF
--- a/src/components/SignupForm/index.jsx
+++ b/src/components/SignupForm/index.jsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 import theme from 'styles/theme';
 import PropTypes from 'prop-types';
 import Text from 'components/basic/Text';
+import useValidInputs from 'hooks/useValidInputs';
 
 const StyledForm = styled.form`
   margin-top: 54px;
@@ -66,55 +67,51 @@ const SignupForm = ({
   inValidPasswordCheck = false,
 }) => {
   const [currentEmailInvalid, setEmailInvalid] = useState(inValidEmail);
-  const [currentPasswordInvalid, setPasswordInvalid] =
-    useState(inValidPassword);
-  const [currentPasswordCheckInvalid, setPasswordCheckInvalid] =
-    useState(inValidPasswordCheck);
-  const [currentFullNameInvalid, setFullNameInvalid] =
-    useState(inValidFullName);
-  const { isLoading, values, errors, handleChange, handleSubmit } = useForm({
-    initialValues: {
-      email: '',
-      password: '',
-    },
-    onSubmit,
-    validate: ({ email, password, fullName, passwordCheck }) => {
-      const newErrors = {};
+  const [currentPasswordInvalid, setPasswordInvalid] = useState(inValidPassword);
+  const [currentPasswordCheckInvalid, setPasswordCheckInvalid] = useState(inValidPasswordCheck);
+  const [currentFullNameInvalid, setFullNameInvalid] = useState(inValidFullName);
+  const { isLoading, values, errors, handleChange, handleSubmit, errorPassword, errorfullName } =
+    useValidInputs({
+      initialValues: {
+        email: '',
+        password: '',
+      },
+      onSubmit,
+      validate: ({ email, password, fullName, passwordCheck }) => {
+        const newErrors = {};
 
-      if (!email) {
-        newErrors.email = '! 이메일을 입력해주세요.';
-        setEmailInvalid(true);
-      } else if (!emailValid(email)) {
-        newErrors.email = '! 이메일 형식이 아닙니다.';
-        setEmailInvalid(true);
-      } else {
-        setEmailInvalid(false);
-      }
-      if (!fullName) {
-        newErrors.fullName = '! 닉네임을 입력해주세요';
-        setFullNameInvalid(true);
-      } else if (fullNameValid(fullName)) {
-        newErrors.fullName = '! 특수문자를 제외한 닉네임을 입력해주세요';
-        setFullNameInvalid(true);
-      } else {
-        setFullNameInvalid(false);
-      }
-      if (!password || password.length < 8 || password.length > 10) {
-        newErrors.password = '! 비밀번호를 8-10자 사이로 입력해주세요.';
-        setPasswordInvalid(true);
-      } else {
-        setPasswordInvalid(false);
-      }
-      if (password !== passwordCheck) {
-        newErrors.passwordCheck = '! 비밀번호가 일치하지 않습니다.';
-        setPasswordCheckInvalid(true);
-      } else {
-        setPasswordCheckInvalid(false);
-      }
+        if (!email) {
+          newErrors.email = '! 이메일을 입력해주세요.';
+          setEmailInvalid(true);
+        } else if (!emailValid(email)) {
+          newErrors.email = '! 이메일 형식이 아닙니다.';
+          setEmailInvalid(true);
+        } else {
+          setEmailInvalid(false);
+        }
+        if (!fullName) {
+          newErrors.fullName = '! 닉네임을 입력해주세요.';
+          setFullNameInvalid(true);
+        } else {
+          setFullNameInvalid(false);
+        }
+        if (!password) {
+          newErrors.password = '! 비밀번호를 입력해주세요.';
+          setPasswordInvalid(true);
+        } else {
+          setPasswordInvalid(false);
+        }
+        if (password !== passwordCheck) {
+          newErrors.passwordCheck = '! 비밀번호가 일치하지 않습니다.';
+          setPasswordCheckInvalid(true);
+        } else {
+          setPasswordCheckInvalid(false);
+        }
 
-      return newErrors;
-    },
-  });
+        return newErrors;
+      },
+      max: 10,
+    });
 
   return (
     <StyledForm onSubmit={handleSubmit}>
@@ -138,11 +135,15 @@ const SignupForm = ({
           height={'70'}
           label={''}
           fontSize={18}
-          inValid={currentFullNameInvalid}
+          inValid={currentFullNameInvalid || errorfullName ? true : false}
           placeholder={'닉네임을 입력해주세요.'}
           onChange={handleChange}
         ></Input>
-        {errors.fullName && <ErrorText>{errors.fullName}</ErrorText>}
+        {errorfullName ? (
+          <ErrorText>{errorfullName}</ErrorText>
+        ) : (
+          errors.fullName && <ErrorText>{errors.fullName}</ErrorText>
+        )}
       </InputWrapper>
       <InputWrapper>
         <Input
@@ -152,11 +153,16 @@ const SignupForm = ({
           height={'70'}
           label={''}
           fontSize={18}
-          inValid={currentPasswordInvalid}
+          inValid={currentPasswordInvalid || errorPassword ? true : false}
           placeholder={'비밀번호를 입력해주세요.'}
           onChange={handleChange}
+          value={values.password}
         ></Input>
-        {errors.password && <ErrorText>{errors.password}</ErrorText>}
+        {errorPassword ? (
+          <ErrorText>{errorPassword}</ErrorText>
+        ) : (
+          errors.password && <ErrorText>{errors.password}</ErrorText>
+        )}
       </InputWrapper>
       <InputWrapper>
         <Input

--- a/src/components/basic/Input/index.jsx
+++ b/src/components/basic/Input/index.jsx
@@ -21,9 +21,8 @@ const StyledInput = styled.input`
   padding: 22px 22px;
   border-radius: 15px;
   box-sizing: border-box;
-  border: 1px solid
-    ${({ inValid }) =>
       inValid ? theme.color.mainRed : theme.color.borderNormal};
+  border: 1px solid ${({ inValid }) => (inValid ? theme.color.mainRed : theme.color.borderNormal)};
 
   ::placeholder {
     color: #a3a3a3;
@@ -45,6 +44,7 @@ const NewInput = ({
   fontSize = '18px',
   placeholder,
   onChange,
+  value,
   ...props
 }) => {
   const InputStyle = {
@@ -69,6 +69,7 @@ const NewInput = ({
         inputStyle={InputStyle}
         onChange={handleChange}
         inValid={inValid}
+        value={value}
       />
     </InputWrapper>
   );

--- a/src/hooks/useValidInputs.js
+++ b/src/hooks/useValidInputs.js
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+
+const useValidInputs = ({ initialValues, onSubmit, validate, max = 0 }) => {
+  const [values, setValues] = useState(initialValues);
+  const [errors, setErrors] = useState({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorfullName, setErrorfullName] = useState('');
+  const [errorPassword, setErrorPassword] = useState('');
+  const handleChange = (e) => {
+    // eslint-disable-next-line
+    const reg = /[`~!@#$%^&*()_|+\-=?;:'",.<>\s\{\}\[\]\\\/]/gi;
+
+    const { name, value } = e.target;
+
+    if (name === 'password') {
+      if (max && value.length > max) {
+        setErrorPassword('! 비밀번호를 8-10자 사이로 입력해주세요.');
+        setValues({ ...values, [name]: value.slice(0, max) });
+        return;
+      }
+
+      setErrorPassword('');
+      setValues({ ...values, [name]: value });
+    }
+    if (name === 'fullName') {
+      if (reg.test(value)) {
+        setErrorfullName('! 특수문자를 제외한 닉네임을 입력해주세요.');
+        return;
+      }
+      setErrorfullName('');
+      setValues({ ...values, [name]: value });
+    }
+
+    setValues({ ...values, [name]: value });
+  };
+
+  const handleSubmit = async (e) => {
+    setIsLoading(true);
+    e.preventDefault();
+    const newErrors = validate ? validate(values) : {};
+    if (Object.keys(newErrors).length === 0) {
+      await onSubmit(values);
+    }
+    setErrors(newErrors);
+    setIsLoading(false);
+  };
+  return {
+    values,
+    errors,
+    errorPassword,
+    errorfullName,
+    isLoading,
+    handleChange,
+    handleSubmit,
+  };
+};
+
+export default useValidInputs;


### PR DESCRIPTION
## PR 템플릿
## ✅ 이슈 번호
#60 
## 📌 기능 설명 <!-- 기능을 대략적으로 설명해주세요 -->
기존에는 회원가입 버튼을 눌러야 validate를 하고 error text를 출력했었는데,
피드백 주신 대로 onChange이벤트를 통해 fullName, 비밀번호는 제출 전에 validation 하는 방법으로 수정하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 요구 사항과 실제 구현 내용을 작성해 주세요 -->
1. useValidInputs
![image](https://user-images.githubusercontent.com/93373357/174286009-73c148da-8514-40f3-abd3-56744a612c70.png)
기존 useValidInput은 하나의 input만들 제어하게 설계되어 있는것 같아 useValidInputs hook을 만들어 사용하였습니다.

2. 비밀번호 길이 제한
![image](https://user-images.githubusercontent.com/93373357/174286266-5f1e618d-39d0-4fa8-9cc5-2a66f36b6ccc.png)

3. 닉네임 특수문자 경고
![image](https://user-images.githubusercontent.com/93373357/174286380-a06bd89c-5964-442a-bb4f-bf252170c1b7.png)


## 구현 결과

https://user-images.githubusercontent.com/93373357/174285631-b3860222-9d0a-4dca-9809-fef3edfcc956.mp4


<!-- 이미지를 첨부해주세요. -->

<!-- issue 클로즈시, resolve 명시
ex: resolve #이슈번호 - 기능 이슈
    fix #이슈번호 - 버그 이슈
    close #이슈번호 - etc 이슈
 -->
