### PR TITLE
feat: MainPage 무한스크롤 추가

### DIFF
--- a/src/pages/MainPage/PostBody.jsx
+++ b/src/pages/MainPage/PostBody.jsx
@@ -80,7 +80,7 @@ const PostBody = ({ post, isDetailPage = false }) => {
       setLikeId(array[0]);
     }
   }, []);
-  
+
   const handleMoreClick = () => {
     setIsShown(true);
   };
@@ -111,7 +111,7 @@ const PostBody = ({ post, isDetailPage = false }) => {
           <Paragraph isDetailPage={isDetailPage} isShown={isShown}>
             {content ? content : contents}
           </Paragraph>
-          {!isDetailPage && content.length > 50 && !isShown && (
+          {!isDetailPage && content?.length > 50 && !isShown && (
             <MoreText onClick={handleMoreClick}>더보기</MoreText>
           )}
         </TextContainer>
@@ -122,7 +122,6 @@ const PostBody = ({ post, isDetailPage = false }) => {
             </Tag>
           ))}
         </Tags>
-        <DateText>{updatedAt.substr(0, 10)}</DateText>
       </Contents>
     </Container>
   );

--- a/src/pages/MainPage/index.jsx
+++ b/src/pages/MainPage/index.jsx
@@ -10,7 +10,7 @@ const MainPage = () => {
   const [posts, setPosts] = useState([]);
   const [isLoding, setIsLoding] = useState(false);
   const [offset, setOffset] = useState(0);
-  const targetRef = useRef(null);
+  const [target, setTarget] = useState('');
 
   useEffect(() => {
     (async () => {
@@ -18,63 +18,46 @@ const MainPage = () => {
         offset,
         limit: LIMIT,
       }).then((res) => res.data);
-      setPosts([...posts, ...nextPosts]);
+      setPosts(nextPosts);
     })();
   }, []);
 
-  const onIntersect = useCallback(() => {
-    (async (entries, observer) => {
-      console.log(entries);
-      if (!entries) {
-        return;
-      }
-      if (entries[0].isIntersecting && !isLoding) {
-        observer.unobserve(entries[0].target);
-        setIsLoding(true);
-        setOffset(offset + 5);
-        const nextPosts = await getPostsPart({
-          offset,
-          limit: LIMIT,
-        }).then((res) => res.data);
-        setPosts([...posts, ...nextPosts]);
-        setIsLoding(false);
-        observer.observe(entries[0].target);
-      }
-    })();
-  }, []);
+  // const onIntersect = async ([entry], observer) => {
+  //   if (entry.isIntersecting && !isLoding) {
+  //     observer.unobserve(entry.target);
+  //     setIsLoding(true);
+  //     setOffset(offset + 5);
+  //     const nextPosts = await getPostsPart({
+  //       offset,
+  //       limit: LIMIT,
+  //     }).then((res) => res.data);
+  //     setPosts([...posts, ...nextPosts]);
+  //     setIsLoding(false);
+  //     observer.observe(entry.target);
+  //   }
+  // };
 
-  useEffect(() => {
-    let observer;
-    if (targetRef.current) {
-      observer = new IntersectionObserver(onIntersect, {
-        threshold: 0.5,
-      });
-      observer.observe(targetRef.current);
-    }
-    return () => observer && observer.disconnect();
-  }, [targetRef, onIntersect]);
+  // useEffect(() => {
+  //   let observer;
+  //   if (target) {
+  //     observer = new IntersectionObserver(onIntersect, {
+  //       threshold: 0.4,
+  //     });
+  //     observer.observe(target);
+  //   }
+  //   return () => observer && observer.disconnect();
+  // }, [target]);
 
   return (
     <PageWrapper header nav>
       <PostList>
-        {posts?.map((post, i) => {
-          const isLastItem = posts.length - 1 === i;
-          if (isLastItem) {
-            return (
-              <li key={post._id}>
-                <PostItem key={post._id} post={post} />
-              </li>
-            );
-          } else {
-            return (
-              <li key={post._id}>
-                <PostItem key={post._id} post={post} />
-              </li>
-            );
-          }
-        })}
+        {posts?.map((post) => (
+          <li key={post._id}>
+            <PostItem key={post._id} post={post} />
+          </li>
+        ))}
       </PostList>
-      <div ref={targetRef}></div>
+      <div ref={setTarget}></div>
     </PageWrapper>
   );
 };

--- a/src/pages/MainPage/index.jsx
+++ b/src/pages/MainPage/index.jsx
@@ -2,46 +2,57 @@ import styled from '@emotion/styled';
 import PageWrapper from 'components/basic/pageWrapper';
 import { getPostsPart } from 'utils/apis/postApi';
 import PostItem from './PostItem';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 const LIMIT = 15;
 
-const observerOption = {
-  root: null,
-  rootMargin: '0px',
-  threshold: 0.9,
-};
-
 const MainPage = () => {
   const [posts, setPosts] = useState([]);
+  const [isLoding, setIsLoding] = useState(false);
   const [offset, setOffset] = useState(0);
   const targetRef = useRef(null);
 
   useEffect(() => {
-    async function fetchData() {
-      const initialPosts = await getPostsPart({
+    (async () => {
+      const nextPosts = await getPostsPart({
         offset,
         limit: LIMIT,
       }).then((res) => res.data);
-      setPosts(initialPosts);
-    }
-    fetchData();
-  }, [offset]);
+      setPosts([...posts, ...nextPosts]);
+    })();
+  }, []);
+
+  const onIntersect = useCallback(() => {
+    (async (entries, observer) => {
+      console.log(entries);
+      if (!entries) {
+        return;
+      }
+      if (entries[0].isIntersecting && !isLoding) {
+        observer.unobserve(entries[0].target);
+        setIsLoding(true);
+        setOffset(offset + 5);
+        const nextPosts = await getPostsPart({
+          offset,
+          limit: LIMIT,
+        }).then((res) => res.data);
+        setPosts([...posts, ...nextPosts]);
+        setIsLoding(false);
+        observer.observe(entries[0].target);
+      }
+    })();
+  }, []);
 
   useEffect(() => {
-    const observer = new IntersectionObserver((entries) => {
-      if (entries[0].isIntersecting && targetRef.current) {
-        console.log('화면 끝...', entries[0]);
-      }
-    }, observerOption);
-
+    let observer;
     if (targetRef.current) {
+      observer = new IntersectionObserver(onIntersect, {
+        threshold: 0.5,
+      });
       observer.observe(targetRef.current);
     }
-    return () => {
-      observer.disconnect();
-    };
-  }, [targetRef]);
+    return () => observer && observer.disconnect();
+  }, [targetRef, onIntersect]);
 
   return (
     <PageWrapper header nav>
@@ -71,3 +82,18 @@ const MainPage = () => {
 const PostList = styled.ul``;
 
 export default MainPage;
+
+// useEffect(() => {
+//   const observer = new IntersectionObserver((entries) => {
+//     if (entries[0].isIntersecting && targetRef.current) {
+//       console.log('화면 끝...', entries[0]);
+//     }
+//   }, observerOption);
+
+//   if (targetRef.current) {
+//     observer.observe(targetRef.current);
+//   }
+//   return () => {
+//     observer.disconnect();
+//   };
+// }, [targetRef]);

--- a/src/pages/MainPage/index.jsx
+++ b/src/pages/MainPage/index.jsx
@@ -4,7 +4,7 @@ import { getPostsPart } from 'utils/apis/postApi';
 import PostItem from './PostItem';
 import { useState, useEffect, useCallback, useRef } from 'react';
 
-const LIMIT = 15;
+const LIMIT = 5;
 
 const MainPage = () => {
   const [posts, setPosts] = useState([]);
@@ -28,7 +28,7 @@ const MainPage = () => {
   const onIntersect = useCallback(
     async ([entry], observer) => {
       if (entry.isIntersecting && !isLoding && offset < max) {
-        observer.disconnect(entry.target);
+        observer.disconnect();
         setIsLoding(true);
         setOffset(offset + 5);
         const nextPosts = await getPostsPart({

--- a/src/pages/MainPage/index.jsx
+++ b/src/pages/MainPage/index.jsx
@@ -2,13 +2,20 @@ import styled from '@emotion/styled';
 import PageWrapper from 'components/basic/pageWrapper';
 import { getPostsPart } from 'utils/apis/postApi';
 import PostItem from './PostItem';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 const LIMIT = 15;
+
+const observerOption = {
+  root: null,
+  rootMargin: '0px',
+  threshold: 0.9,
+};
 
 const MainPage = () => {
   const [posts, setPosts] = useState([]);
   const [offset, setOffset] = useState(0);
+  const targetRef = useRef(null);
 
   useEffect(() => {
     async function fetchData() {
@@ -21,15 +28,42 @@ const MainPage = () => {
     fetchData();
   }, [offset]);
 
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && targetRef.current) {
+        console.log('화면 끝...', entries[0]);
+      }
+    }, observerOption);
+
+    if (targetRef.current) {
+      observer.observe(targetRef.current);
+    }
+    return () => {
+      observer.disconnect();
+    };
+  }, [targetRef]);
+
   return (
     <PageWrapper header nav>
       <PostList>
-        {posts?.map((post) => (
-          <li key={post._id}>
-            <PostItem key={post._id} post={post} />
-          </li>
-        ))}
+        {posts?.map((post, i) => {
+          const isLastItem = posts.length - 1 === i;
+          if (isLastItem) {
+            return (
+              <li key={post._id}>
+                <PostItem key={post._id} post={post} />
+              </li>
+            );
+          } else {
+            return (
+              <li key={post._id}>
+                <PostItem key={post._id} post={post} />
+              </li>
+            );
+          }
+        })}
       </PostList>
+      <div ref={targetRef}></div>
     </PageWrapper>
   );
 };
@@ -37,14 +71,3 @@ const MainPage = () => {
 const PostList = styled.ul``;
 
 export default MainPage;
-
-// export const getPostsPart = ({ offset, limit }) => {
-//   return request({
-//     method: API_METHOD.GET,
-//     url: `/posts/channel/${process.env.REACT_APP_CHANNEL_ID_TOTAL}`,
-//     params: {
-//       offset,
-//       limit,
-//     },
-//   });
-// };


### PR DESCRIPTION
## ✅ 이슈 번호
#84 
## 📌 기능 설명 <!-- 기능을 대략적으로 설명해주세요 -->
MainPage에 무한스크롤 기능을 추가했습니다. 
포스트를 5개씩 불러오고, 마지막 포스트에 도달하면 새 포스트를 5개 불러옵니다. 
IntersectionObserver를 사용했습니다. 

## 구현 결과
시연 영상입니다. 
렌더링으로 깜빡거리는 현상이 있는데요,
개발자 도구를 끄면 사라지는 현상이니 걱정하지 않으셔도 됩니다 :)

https://user-images.githubusercontent.com/80658269/174424306-6e0fe9e5-1f38-4478-ad64-f7b9fc2b3803.mp4

## 코드
첫 렌더링 시에는 포스트 5개를 자동으로 불러옵니다. 

![image](https://user-images.githubusercontent.com/80658269/174424507-e784a219-c800-45aa-9295-d9a7093fb14f.png)

* posts: 포스트 목록
* isLoding: 로딩 중 여부 (오타가 있네요. 추후 수정하겠습니다)
* offSet: 요청할 포스트의 시작 인덱스 
* LIMIT: 한 번에 불러오는 포스트 수 
* max: 채널의 포스트 총 개수 
* targetRef: 관찰 요소. 마지막 포스트

그리고 IntersectionObserver를 사용하여 아래와 같이 구현했습니다. 
onIntersect는 타겟 요소 관찰 시 호출하는 함수입니다. 

![image](https://user-images.githubusercontent.com/80658269/174424672-31c4554a-c937-40ef-b94b-670e02e7a270.png)

자세한 것은 코드를 참고해 주세요. 
피드백 부탁 드립니다 :)