### PR TITLE
feat: 로그인 / 회원가입 Modal 컴포넌트 수정

### DIFF
--- a/src/contexts/UserContext/handles.jsx
+++ b/src/contexts/UserContext/handles.jsx
@@ -39,9 +39,6 @@ const useHandles = () => {
       if (res.data.token) {
         setLocalToken(res.data.token); // 로그인 성공 시, JWT 토큰 갱신
         navigate('/', { replace: true }); // 메인페이지로 이동
-        alert('로그인 성공');
-      } else {
-        alert('로그인 실패');
       }
       return { user: res.data.user, token: res.data.token };
     },
@@ -56,11 +53,8 @@ const useHandles = () => {
       const { data, error } = await signup(inputData);
       if (data.token) {
         setLocalToken(data.token); // 회원가입 성공 시, JWT 토큰 갱신
-        navigate('/', { replace: true }); // 메인 페이지로 이동 (로그인을 건너뛴다)
-        alert('회원가입 성공');
+        //navigate('/', { replace: true }); // 메인 페이지로 이동 (로그인을 건너뛴다)
         await login(inputData);
-      } else if (error.code === 400) {
-        alert('회원가입 실패');
       }
       return data;
     },

--- a/src/pages/LoginPage/index.jsx
+++ b/src/pages/LoginPage/index.jsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import LoginModal from 'components/LoginModal';
 import { useUserContext } from 'contexts/UserContext';
 import PageWrapper from 'components/basic/pageWrapper';
+import Modal from 'components/Modal';
 
 const LoginWrapper = styled.div`
   width: 100%;
@@ -49,7 +50,14 @@ const LoginPage = () => {
       <LoginWrapper>
         <Logo name={IMAGE_NAMES.LOGO_IMAGE} width={254} height={97}></Logo>
         <LoginForm onSubmit={handleSubmit}></LoginForm>
-        <LoginModal isShow={showModal} onClose={closeModal}></LoginModal>
+        <Modal visible={showModal} onClose={closeModal}>
+          <Modal.Content
+            title="로그인에 실패했어요!"
+            description="이메일 및 비밀번호를 다시 확인해주세요"
+            onClose={closeModal}
+          ></Modal.Content>
+          <Modal.Button onClick={closeModal}>확인</Modal.Button>
+        </Modal>
       </LoginWrapper>
     </PageWrapper>
   );

--- a/src/pages/SignupPage/index.jsx
+++ b/src/pages/SignupPage/index.jsx
@@ -10,6 +10,7 @@ import Text from 'components/basic/Text';
 import useLocalStorage from 'hooks/useLocalStrorage';
 import { useUserContext } from 'contexts/UserContext';
 import PageWrapper from 'components/basic/pageWrapper';
+import Modal from 'components/Modal';
 
 const SignupWrapper = styled.div`
   width: 100%;
@@ -56,7 +57,14 @@ const SignupPage = () => {
       <SignupWrapper>
         <StyledText fontSize={30}>회원가입</StyledText>
         <SignupForm onSubmit={handleSubmit}></SignupForm>
-        <SignupModal isShow={showModal} onClose={closeModal}></SignupModal>
+        <Modal visible={showModal} onClose={closeModal}>
+          <Modal.Content
+            title="회원가입에 실패했어요!"
+            description="이메일 및 비밀번호를 다시 확인해주세요"
+            onClose={closeModal}
+          ></Modal.Content>
+          <Modal.Button onClick={closeModal}>확인</Modal.Button>
+        </Modal>
       </SignupWrapper>
     </PageWrapper>
   );

--- a/src/pages/SignupPage/index.jsx
+++ b/src/pages/SignupPage/index.jsx
@@ -28,15 +28,21 @@ const StyledText = styled(Text)`
 
 const SignupPage = () => {
   const [showModal, setShowModal] = useState(false);
+  const [showLoginModal, setShowLoginModal] = useState(false);
   const [tokenInfo, setTokenInfo] = useLocalStorage('tokenInfo', '');
   const navigate = useNavigate();
   const { onSignup } = useUserContext();
 
-  const openModal = () => {
-    setShowModal(true);
-  };
   const closeModal = () => {
     setShowModal(false);
+  };
+
+  const closeLoginModal = () => {
+    setShowLoginModal(false);
+  };
+
+  const onClick = () => {
+    navigate('/');
   };
 
   const handleSubmit = async ({ email, fullName, password }) => {
@@ -46,9 +52,10 @@ const SignupPage = () => {
         fullName,
         password,
       });
+      setShowLoginModal(true);
     } catch (e) {
       e.message = 'SignupError';
-      openModal();
+      setShowModal(true);
       throw e;
     }
   };
@@ -57,6 +64,14 @@ const SignupPage = () => {
       <SignupWrapper>
         <StyledText fontSize={30}>회원가입</StyledText>
         <SignupForm onSubmit={handleSubmit}></SignupForm>
+        <Modal visible={showLoginModal} onClose={closeLoginModal}>
+          <Modal.Content
+            title="회원가입에 성공했어요!"
+            description="메인 페이지로 이동합니다"
+            onClose={closeLoginModal}
+          ></Modal.Content>
+          <Modal.Button onClick={onClick}>확인</Modal.Button>
+        </Modal>
         <Modal visible={showModal} onClose={closeModal}>
           <Modal.Content
             title="회원가입에 실패했어요!"


### PR DESCRIPTION
## PR 템플릿
## ✅ 이슈 번호

## 📌 기능 설명 <!-- 기능을 대략적으로 설명해주세요 -->
1. 기존 LoginModal / SignupModal 각각 사용하던 방식에서 기본 컴포넌트 사용으로 변경하였습니다.

![image](https://user-images.githubusercontent.com/93373357/174497700-6f3d7720-2c22-49fb-8ee0-d313679529b2.png)

2. 회원가입 성공 후 메인 페이지로 넘어가기 전 Modal으로 사용자 확인

![image](https://user-images.githubusercontent.com/93373357/174497806-e6c8036d-072c-4442-bee6-2bc15f6ec3cf.png)
handleSignup의 navigation 제거

![image](https://user-images.githubusercontent.com/93373357/174497792-d28c704e-7164-4f8b-aac3-776b2e8372a6.png)
확인 버튼 클릭하면 onClick함수 실행되며 메인 페이지로 이동

![image](https://user-images.githubusercontent.com/93373357/174497787-17329718-23dd-4f49-992c-22176d84bf13.png)

![image](https://user-images.githubusercontent.com/93373357/174497765-a469bbde-7885-409d-8f09-402e07c5b365.png)

3. 임시로 사용하던 alert창 삭제하였습니다.

<!-- 이미지를 첨부해주세요. -->

<!-- issue 클로즈시, resolve 명시
ex: resolve #이슈번호 - 기능 이슈
    fix #이슈번호 - 버그 이슈
    close #이슈번호 - etc 이슈
 -->
