### PR TITLE
feature: 게시글 수정 페이지(postEditPage) 구현

### DIFF
--- a/src/components/PostTextArea/index.jsx
+++ b/src/components/PostTextArea/index.jsx
@@ -1,0 +1,50 @@
+import styled from '@emotion/styled';
+import { useRef } from 'react';
+
+import theme from 'styles/theme';
+
+const { fontNormal, borderNormal, mainBlack } = theme.color;
+
+const StyledTextArea = styled.textarea`
+  margin-top: 20px;
+  width: 100%;
+  border: 1px solid ${borderNormal};
+  border-radius: 15px;
+  padding: 23px 20px;
+  resize: none;
+  font-size: 20px;
+  color: ${mainBlack};
+  overflow: hidden;
+
+  ::placeholder {
+    color: ${fontNormal};
+  }
+  &:focus {
+    border: 1px solid ${borderNormal};
+  }
+`;
+
+const PostTextArea = ({ children, onChange, placeholder, rows, cols, value }) => {
+  const textRef = useRef();
+
+  const handleResizeHeight = (e) => {
+    textRef.current.style.height = 'auto';
+    textRef.current.style.height = textRef.current.scrollHeight + 'px';
+    onChange(textRef.current.value);
+  };
+
+  return (
+    <StyledTextArea
+      ref={textRef}
+      onChange={handleResizeHeight}
+      placeholder={placeholder}
+      value={value}
+      rows={rows}
+      cols={cols}
+    >
+      {children}
+    </StyledTextArea>
+  );
+};
+
+export default PostTextArea;

--- a/src/components/UploadImage/index.jsx
+++ b/src/components/UploadImage/index.jsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import theme from 'styles/theme';
 import { IMAGE_URLS } from 'utils/constants/images';
+import { useEffect } from 'react';
 
 const { backgroundGreen } = theme.color;
 const { POST_DEFAULT_IMG } = IMAGE_URLS;
@@ -39,7 +40,7 @@ const ImageInner = styled.div`
   /* background-color: white; */
 `;
 
-const UploadImage = ({ onChange, defaultImage = null, ...props }) => {
+const UploadImage = ({ onChange, defaultImage, ...props }) => {
   const [imageSrc, setImageSrc] = useState(defaultImage);
   const fileInputRef = useRef(null);
 
@@ -53,24 +54,20 @@ const UploadImage = ({ onChange, defaultImage = null, ...props }) => {
     };
   };
 
+  useEffect(() => {
+    setImageSrc(defaultImage);
+  }, [defaultImage]);
+
   const ImageStyle = {
     backgroundImage: `url(${imageSrc ? imageSrc : POST_DEFAULT_IMG}`,
   };
 
   return (
     <ImageWrapper>
-      <ImageLoad
-        onClick={() => fileInputRef.current.click()}
-        style={{ ...props.style }}
-      >
+      <ImageLoad onClick={() => fileInputRef.current.click()} style={{ ...props.style }}>
         <ImageInner style={{ ...ImageStyle }} />
       </ImageLoad>
-      <FileInput
-        ref={fileInputRef}
-        type="file"
-        id="file"
-        onChange={handleFileChange}
-      />
+      <FileInput ref={fileInputRef} type="file" id="file" onChange={handleFileChange} />
     </ImageWrapper>
   );
 };

--- a/src/pages/PostAddPage/index.jsx
+++ b/src/pages/PostAddPage/index.jsx
@@ -122,6 +122,15 @@ const PostAddPage = () => {
     <>
       <PageFixed title="게시물 등록" header prev>
         <UploadImage onChange={onFileChange} />
+        <button
+          onClick={() => {
+            navigate('/post/edit/62ae4c512ba3b3676bda2141', {
+              state: '/post/edit/62ae4c512ba3b3676bda2141',
+            });
+          }}
+        >
+          edit버튼 테스트
+        </button>
         <TagAddForm onAddTag={onAddTag} onRemoveTag={onRemoveTag} tags={tags} />
         <TextArea
           ref={textRef}

--- a/src/pages/PostEditPage/index.jsx
+++ b/src/pages/PostEditPage/index.jsx
@@ -53,7 +53,15 @@ const PageFixed = styled(PageWrapper)`
 
 // 내 게시물이 아닌데 수정하려고 할 경우 내보내야 할 듯
 
-const PostEditPage = (props) => {
+const page = {
+  create: {
+    title: '게시물 등록',
+  },
+  edit: {
+    title: '게시물 수정',
+  },
+};
+const PostEditPage = () => {
   const [tags, setTags] = useState([]);
   const [imgSrc, setImgSrc] = useState('');
   const [content, setContent] = useState('');
@@ -66,6 +74,7 @@ const PostEditPage = (props) => {
   const location = useLocation();
   const textRef = useRef();
 
+  console.log(location.state, 'location.state');
   const handleResizeHeight = useCallback(
     (e) => {
       textRef.current.style.height = 'auto';
@@ -79,14 +88,13 @@ const PostEditPage = (props) => {
   const currentPage = location.pathname.split('/')[2]; // 페이지 구분
 
   const { id } = useParams();
-  console.log(location.pathname.split('/')[2], 'location');
 
   const getCurrentPost = useCallback(async () => {
     const result = await getPostData(id).then((res) => res.data);
     const title = JSON.parse(result.title);
     console.log(result, 'result');
 
-    // setImgSrc(result.image);
+    // ImgSrc(result.image);
     setContent(title.content);
     setTags(title.tags);
     setCurrentPost(result);
@@ -114,9 +122,11 @@ const PostEditPage = (props) => {
   );
 
   const onClickAddBtn = async () => {
-    // Edit페이지일 경우는 imgSrc가 없어도 됨
+    if (!token) {
+      return;
+    }
 
-    if (token && currentPage === 'create') {
+    if (currentPage === 'create') {
       if (!imgSrc || !content) {
         setModalMessage(!imgSrc ? '이미지를 등록해주세요!' : '게시글을 작성해주세요!');
         setIsModal(true);
@@ -130,11 +140,11 @@ const PostEditPage = (props) => {
         channelId: '62a04aa2703fdd3a82b4e66e',
       });
       const result = await addPost(token, formData);
-      console.log(result);
+      console.log(result, '포스트 등록 결과');
       navigate('/');
     }
 
-    if (token && currentPage === 'edit') {
+    if (currentPage === 'edit') {
       if (!content) {
         setModalMessage('게시글을 작성해주세요!');
         setIsModal(true);
@@ -163,19 +173,16 @@ const PostEditPage = (props) => {
     setIsModal(false);
   };
 
-  //추가된 부분
   useEffect(() => {
     if (currentPage === 'edit') {
-      getCurrentPost();
-      console.log('현재 페이지는 Edit 페이지 입니다.');
+      location.state?.post ? setCurrentPost(location.state.post) : getCurrentPost();
     }
-  }, [getCurrentPost, currentPage]);
+  }, [getCurrentPost, currentPage, location.state.post]);
 
   return (
     <>
-      <PageFixed title="게시물 수정" header prev>
-        <UploadImage onChange={onFileChange} defaultImage={currentPost?.image} />{' '}
-        {/* default 이미지 받기 */}
+      <PageFixed title={page[currentPage].title} header prev>
+        <UploadImage onChange={onFileChange} defaultImage={currentPost?.image} />
         <TagAddForm onAddTag={onAddTag} onRemoveTag={onRemoveTag} tags={tags} />
         <TextArea
           ref={textRef}
@@ -185,11 +192,7 @@ const PostEditPage = (props) => {
           rows={10}
         ></TextArea>
         <FixedContainer bottom style={{ padding: 15 }}>
-          {currentPage === 'create' ? (
-            <Button onClick={onClickAddBtn}>게시물 등록</Button>
-          ) : (
-            <Button onClick={onClickAddBtn}>게시물 수정</Button>
-          )}
+          <Button onClick={onClickAddBtn}>{page[currentPage].title}</Button>
         </FixedContainer>
         <Modal visible={isModal} onClose={onCloseModal}>
           <Modal.Content title={modalMessage} />

--- a/src/pages/PostEditPage/index.jsx
+++ b/src/pages/PostEditPage/index.jsx
@@ -6,37 +6,15 @@ import UploadImage from 'components/UploadImage';
 import TagAddForm from 'components/TagAddForm';
 import PageWrapper from 'components/basic/pageWrapper';
 import FixedContainer from 'components/FixedContainer';
+import Modal from 'components/Modal';
+import PostTextArea from 'components/PostTextArea';
+
 import useLocalToken from 'hooks/useLocalToken';
 import { addPost, getPostData, updatePost } from 'utils/apis/postApi';
 import theme from 'styles/theme';
-import Modal from 'components/Modal';
-import { IMAGE_URLS } from 'utils/constants/images';
-
 import { imageToFile, objectToForm } from 'utils/functions/converter';
-import { useRef } from 'react';
 
-const { fontNormal, borderNormal, mainBlack } = theme.color;
 const { headerHeight } = theme.value;
-const { POST_DEFAULT_IMG } = IMAGE_URLS;
-
-const TextArea = styled.textarea`
-  margin-top: 20px;
-  width: 100%;
-  border: 1px solid ${borderNormal};
-  border-radius: 15px;
-  padding: 23px 20px;
-  resize: none;
-  font-size: 20px;
-  color: ${mainBlack};
-  overflow: hidden;
-
-  ::placeholder {
-    color: ${fontNormal};
-  }
-  &:focus {
-    border: 1px solid ${borderNormal};
-  }
-`;
 
 const PageFixed = styled(PageWrapper)`
   position: fixed;
@@ -51,8 +29,6 @@ const PageFixed = styled(PageWrapper)`
   }
 `;
 
-// 내 게시물이 아닌데 수정하려고 할 경우 내보내야 할 듯
-
 const page = {
   create: {
     title: '게시물 등록',
@@ -61,6 +37,7 @@ const page = {
     title: '게시물 수정',
   },
 };
+
 const PostEditPage = () => {
   const [tags, setTags] = useState([]);
   const [imgSrc, setImgSrc] = useState('');
@@ -72,20 +49,13 @@ const PostEditPage = () => {
 
   const navigate = useNavigate();
   const location = useLocation();
-  const textRef = useRef();
 
-  console.log(location.state, 'location.state');
-  const handleResizeHeight = useCallback(
-    (e) => {
-      textRef.current.style.height = 'auto';
-      textRef.current.style.height = textRef.current.scrollHeight + 'px';
-      setContent(e.target.value);
-    },
-    [textRef],
-  );
-
-  //추가된 부분
   const currentPage = location.pathname.split('/')[2]; // 페이지 구분
+  console.log(location.state, 'location.state');
+
+  const onChangeContent = useCallback((value) => {
+    setContent(value);
+  }, []);
 
   const { id } = useParams();
 
@@ -98,7 +68,6 @@ const PostEditPage = () => {
     setContent(title.content);
     setTags(title.tags);
     setCurrentPost(result);
-    console.log(result.image);
   }, [id]);
 
   // 추가된 부분
@@ -177,20 +146,19 @@ const PostEditPage = () => {
     if (currentPage === 'edit') {
       location.state?.post ? setCurrentPost(location.state.post) : getCurrentPost();
     }
-  }, [getCurrentPost, currentPage, location.state.post]);
+  }, [getCurrentPost, currentPage, location.state?.post]);
 
   return (
     <>
       <PageFixed title={page[currentPage].title} header prev>
         <UploadImage onChange={onFileChange} defaultImage={currentPost?.image} />
         <TagAddForm onAddTag={onAddTag} onRemoveTag={onRemoveTag} tags={tags} />
-        <TextArea
-          ref={textRef}
-          onChange={handleResizeHeight}
+        <PostTextArea
+          onChange={onChangeContent}
           placeholder="내 식물의 성장 글을 작성해주세요."
           value={content}
           rows={10}
-        ></TextArea>
+        ></PostTextArea>
         <FixedContainer bottom style={{ padding: 15 }}>
           <Button onClick={onClickAddBtn}>{page[currentPage].title}</Button>
         </FixedContainer>

--- a/src/pages/PostEditPage/index.jsx
+++ b/src/pages/PostEditPage/index.jsx
@@ -1,5 +1,203 @@
-const PostEditPage = () => {
-  return <div>PostEditPage</div>;
+import styled from '@emotion/styled';
+import { useCallback, useEffect, useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import Button from 'components/basic/Button';
+import UploadImage from 'components/UploadImage';
+import TagAddForm from 'components/TagAddForm';
+import PageWrapper from 'components/basic/pageWrapper';
+import FixedContainer from 'components/FixedContainer';
+import useLocalToken from 'hooks/useLocalToken';
+import { addPost, getPostData, updatePost } from 'utils/apis/postApi';
+import theme from 'styles/theme';
+import Modal from 'components/Modal';
+import { IMAGE_URLS } from 'utils/constants/images';
+
+import { imageToFile, objectToForm } from 'utils/functions/converter';
+import { useRef } from 'react';
+
+const { fontNormal, borderNormal, mainBlack } = theme.color;
+const { headerHeight } = theme.value;
+const { POST_DEFAULT_IMG } = IMAGE_URLS;
+
+const TextArea = styled.textarea`
+  margin-top: 20px;
+  width: 100%;
+  border: 1px solid ${borderNormal};
+  border-radius: 15px;
+  padding: 23px 20px;
+  resize: none;
+  font-size: 20px;
+  color: ${mainBlack};
+  overflow: hidden;
+
+  ::placeholder {
+    color: ${fontNormal};
+  }
+  &:focus {
+    border: 1px solid ${borderNormal};
+  }
+`;
+
+const PageFixed = styled(PageWrapper)`
+  position: fixed;
+  overflow: auto;
+  height: calc(100% - ${headerHeight});
+  width: 100%;
+  max-width: 500px;
+  bottom: 100px;
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+// 내 게시물이 아닌데 수정하려고 할 경우 내보내야 할 듯
+
+const PostEditPage = (props) => {
+  const [tags, setTags] = useState([]);
+  const [imgSrc, setImgSrc] = useState('');
+  const [content, setContent] = useState('');
+  const [isModal, setIsModal] = useState(false);
+  const [modalMessage, setModalMessage] = useState('');
+  const [token, setValue] = useLocalToken();
+  const [currentPost, setCurrentPost] = useState();
+
+  const navigate = useNavigate();
+  const location = useLocation();
+  const textRef = useRef();
+
+  const handleResizeHeight = useCallback(
+    (e) => {
+      textRef.current.style.height = 'auto';
+      textRef.current.style.height = textRef.current.scrollHeight + 'px';
+      setContent(e.target.value);
+    },
+    [textRef],
+  );
+
+  //추가된 부분
+  const currentPage = location.pathname.split('/')[2]; // 페이지 구분
+
+  const { id } = useParams();
+  console.log(location.pathname.split('/')[2], 'location');
+
+  const getCurrentPost = useCallback(async () => {
+    const result = await getPostData(id).then((res) => res.data);
+    const title = JSON.parse(result.title);
+    console.log(result, 'result');
+
+    // setImgSrc(result.image);
+    setContent(title.content);
+    setTags(title.tags);
+    setCurrentPost(result);
+    console.log(result.image);
+  }, [id]);
+
+  // 추가된 부분
+
+  const onAddTag = useCallback(
+    (value) => {
+      const tag = `#${value}`;
+      if (tags.length < 5) {
+        setTags([...tags, tag]);
+      }
+    },
+    [tags],
+  );
+
+  const onRemoveTag = useCallback(
+    (index) => {
+      const updateTags = tags.filter((_, itemIndex) => itemIndex !== index);
+      setTags(updateTags);
+    },
+    [tags],
+  );
+
+  const onClickAddBtn = async () => {
+    // Edit페이지일 경우는 imgSrc가 없어도 됨
+
+    if (token && currentPage === 'create') {
+      if (!imgSrc || !content) {
+        setModalMessage(!imgSrc ? '이미지를 등록해주세요!' : '게시글을 작성해주세요!');
+        setIsModal(true);
+        return;
+      }
+      const title = JSON.stringify({ content, tags });
+      const ImageBlob = imageToFile(imgSrc);
+      const formData = await objectToForm({
+        title,
+        image: ImageBlob,
+        channelId: '62a04aa2703fdd3a82b4e66e',
+      });
+      const result = await addPost(token, formData);
+      console.log(result);
+      navigate('/');
+    }
+
+    if (token && currentPage === 'edit') {
+      if (!content) {
+        setModalMessage('게시글을 작성해주세요!');
+        setIsModal(true);
+        return;
+      }
+
+      const title = JSON.stringify({ content, tags });
+      const ImageBlob = imgSrc ? imageToFile(imgSrc) : null;
+      const formData = await objectToForm({
+        postId: id,
+        title,
+        image: ImageBlob,
+        channelId: '62a04aa2703fdd3a82b4e66e',
+      });
+      const result = await updatePost(token, formData);
+      console.log(result, '포스트 수정 결과');
+      navigate('/');
+    }
+  };
+
+  const onFileChange = useCallback((src) => {
+    setImgSrc(src);
+  }, []);
+
+  const onCloseModal = () => {
+    setIsModal(false);
+  };
+
+  //추가된 부분
+  useEffect(() => {
+    if (currentPage === 'edit') {
+      getCurrentPost();
+      console.log('현재 페이지는 Edit 페이지 입니다.');
+    }
+  }, [getCurrentPost, currentPage]);
+
+  return (
+    <>
+      <PageFixed title="게시물 수정" header prev>
+        <UploadImage onChange={onFileChange} defaultImage={currentPost?.image} />{' '}
+        {/* default 이미지 받기 */}
+        <TagAddForm onAddTag={onAddTag} onRemoveTag={onRemoveTag} tags={tags} />
+        <TextArea
+          ref={textRef}
+          onChange={handleResizeHeight}
+          placeholder="내 식물의 성장 글을 작성해주세요."
+          value={content}
+          rows={10}
+        ></TextArea>
+        <FixedContainer bottom style={{ padding: 15 }}>
+          {currentPage === 'create' ? (
+            <Button onClick={onClickAddBtn}>게시물 등록</Button>
+          ) : (
+            <Button onClick={onClickAddBtn}>게시물 수정</Button>
+          )}
+        </FixedContainer>
+        <Modal visible={isModal} onClose={onCloseModal}>
+          <Modal.Content title={modalMessage} />
+          <Modal.Button onClick={onCloseModal}>확인</Modal.Button>
+        </Modal>
+      </PageFixed>
+    </>
+  );
 };
 
 export default PostEditPage;

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -23,7 +23,7 @@ const Router = () => {
       <Route path="/login" element={<LoginPage />} />
       <Route path="/signup" element={<SignupPage />} />
       <Route path="/" element={<MainPage />} />
-      <Route path="/post/create" element={<PostAddPage />} />
+      <Route path="/post/create" element={<PostEditPage />} />
       <Route path="/post/edit/:id" element={<PostEditPage />} />
       <Route path="/post/detail/:id" element={<PostDetailPage />} />
       <Route path="/mypage" element={<MyPage />} />

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -24,7 +24,7 @@ const Router = () => {
       <Route path="/signup" element={<SignupPage />} />
       <Route path="/" element={<MainPage />} />
       <Route path="/post/create" element={<PostAddPage />} />
-      <Route path="/post/edit" element={<PostEditPage />} />
+      <Route path="/post/edit/:id" element={<PostEditPage />} />
       <Route path="/post/detail/:id" element={<PostDetailPage />} />
       <Route path="/mypage" element={<MyPage />} />
       <Route path="/user/:id" element={<UserPage />} />

--- a/src/utils/apis/postApi.js
+++ b/src/utils/apis/postApi.js
@@ -71,11 +71,6 @@ export const addPost = (token, data) => {
   FormData를 전송하는 것이 필요. 아래와 같이 FormData로 변환 후 전송한다. (테스트 필요)
 */
 export const updatePost = (token, data) => {
-  const submitData = { ...data, meta: JSON.stringify(data.meta) };
-  const formData = new FormData();
-  Object.keys(submitData).forEach((key) => formData.append(key, submitData[key]));
-  formData.append('channelId', channelId);
-
   return request({
     method: API_METHOD.PUT,
     url: `/posts/update`,
@@ -83,7 +78,7 @@ export const updatePost = (token, data) => {
       'Content-Type': `multipart/form-data`,
       Authorization: `Bearer ${token}`,
     },
-    data: formData,
+    data: data,
   });
 };
 


### PR DESCRIPTION
## PR 템플릿
## ✅ 이슈 번호

## 📌 기능 설명 <!-- 기능을 대략적으로 설명해주세요 -->

- 게시물을 수정하는 페이지입니다.
- 게시물 등록 페이지와 유사하여 공통된 페이지를 사용하도록 하였습니다.
( /post/edit/:id , /post/create 모두 한 개의 페이지 컴포넌트를 사용합니다.)
- UI나 기본적으로 구현하는 내용은 비슷하지만 처리하는 과정이 조금 다른 부분이 있어서
로직이 복잡해보이는 상태입니다.
- 게시물 수정경로(/post/edit/:id)로 접근할 때 전달된 state.post가 있다면 해당 포스트 객체를 활용하고
없다면 URL의 Id에 접근하여 서버에 요청을 받게 됩니다.
=> 실제 state.post 데이터가 전달되는 기능이 구현되지 않은 상태라 정확한 테스트는 하지 못했고,
merge 후 다시 테스트를 해 볼 예정입니다.

- 한 페이지에 다루는 내용이 많아져서 TextArea부분은 별도 컴포넌트로 분리했습니다.
![image](https://user-images.githubusercontent.com/81489300/174502117-c8109456-118a-41c4-90d1-4d2fb55bff22.png)

- UploadImage 컴포넌트에서 default 이미지가 제대로 들어가지 않는 현상이 발생하여 일부 코드를 수정했습니다.


