### PR TITLE
feat: Notification 스타일 / 링크 / 프로필 이미지 수정

### DIFF
--- a/src/components/Card/index.jsx
+++ b/src/components/Card/index.jsx
@@ -18,7 +18,7 @@ const Card = ({
     <Container {...props}>
       <Avatar src={src} alt="유저 프로필 이미지" size={size} />
       <Div gap={gap}>
-        <NotificationText color={color} lineHeight={'24.52px'}>
+        <NotificationText style={{ wordBreak: 'keep-all' }} color={color} lineHeight={'24.52px'}>
           <Text fontWeight={600} fontSize={fontSize}>
             {fullName}
           </Text>

--- a/src/components/NotificationCard/index.jsx
+++ b/src/components/NotificationCard/index.jsx
@@ -8,7 +8,7 @@ const NotificationCard = ({ notificationId, postId, message, fullName, userId, i
     width: 100%;
     height: 129px;
     border-radius: 15px;
-    padding: 35px 80px 35px 30px;
+    padding: 35px 65px 35px 30px;
     margin-bottom: 16px;
     display: flex;
     justify-content: center;

--- a/src/components/NotificationCard/index.jsx
+++ b/src/components/NotificationCard/index.jsx
@@ -2,7 +2,7 @@ import Profile from 'components/Profile';
 import styled from '@emotion/styled';
 import theme from 'styles/theme';
 import Card from 'components/Card';
-const NotificationCard = ({ notificationId, postId, message, fullName, userId, isSeen }) => {
+const NotificationCard = ({ notificationId, postId, message, fullName, userId, isSeen, img }) => {
   const CardWrapper = styled.div`
     background-color: ${theme.color.mainWhite};
     width: 100%;
@@ -15,7 +15,7 @@ const NotificationCard = ({ notificationId, postId, message, fullName, userId, i
   `;
   return (
     <CardWrapper>
-      <Card fullName={fullName} message={message}>
+      <Card src={img} fullName={fullName} message={message}>
         <span>1분 전</span>
       </Card>
     </CardWrapper>

--- a/src/components/NotificationCard/index.jsx
+++ b/src/components/NotificationCard/index.jsx
@@ -1,8 +1,18 @@
-import Profile from 'components/Profile';
 import styled from '@emotion/styled';
 import theme from 'styles/theme';
 import Card from 'components/Card';
-const NotificationCard = ({ notificationId, postId, message, fullName, userId, isSeen, img }) => {
+import displayedAt from 'utils/functions/displayedAt';
+
+const NotificationCard = ({
+  notificationId,
+  postId,
+  message,
+  fullName,
+  userId,
+  isSeen,
+  img,
+  createdAt,
+}) => {
   const CardWrapper = styled.div`
     background-color: ${theme.color.mainWhite};
     width: 100%;
@@ -16,7 +26,7 @@ const NotificationCard = ({ notificationId, postId, message, fullName, userId, i
   return (
     <CardWrapper>
       <Card src={img} fullName={fullName} message={message}>
-        <span>1분 전</span>
+        <span>{displayedAt(createdAt)}</span>
       </Card>
     </CardWrapper>
   );

--- a/src/pages/NotificationPage/index.jsx
+++ b/src/pages/NotificationPage/index.jsx
@@ -19,7 +19,6 @@ const NotificationPage = () => {
   const [token] = useLocalToken();
   const [notifications, setNotifications] = useState([]);
   const { currentUser } = useUserContext();
-
   useEffect(() => {
     const initNotifications = async () => {
       const fetchedNotifications = await getNotifications(token);
@@ -34,7 +33,7 @@ const NotificationPage = () => {
           return {
             notificationId: notification._id,
             postId: notification.post,
-            message: `님이 ${message}`,
+            message: message ? `님이 ${message}` : undefined,
             userId: userId,
             authorId: _id,
             isSeen: notification.seen,
@@ -63,8 +62,9 @@ const NotificationPage = () => {
               img,
               createdAt,
             }) =>
-              postId ? (
-                <Link to={`/post/detail/${postId}`}>
+              message &&
+              (postId ? (
+                <Link to={`/post/detail/${postId}`} key={notificationId}>
                   <NotificationCard
                     key={notificationId}
                     isSeen={isSeen}
@@ -75,7 +75,7 @@ const NotificationPage = () => {
                   ></NotificationCard>
                 </Link>
               ) : (
-                <Link to={`/user/${authorId}`}>
+                <Link to={`/user/${authorId}`} key={notificationId}>
                   <NotificationCard
                     key={notificationId}
                     isSeen={isSeen}
@@ -85,7 +85,7 @@ const NotificationPage = () => {
                     createdAt={createdAt}
                   ></NotificationCard>
                 </Link>
-              ),
+              )),
           )}
         </NotificationsWrapper>
       </PageWrapper>

--- a/src/pages/NotificationPage/index.jsx
+++ b/src/pages/NotificationPage/index.jsx
@@ -2,8 +2,8 @@ import NotificationCard from 'components/NotificationCard';
 import { getNotifications } from 'utils/apis/userApi';
 import useLocalToken from 'hooks/useLocalToken';
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import styled from '@emotion/styled';
-import Profile from 'components/Profile';
 import { useUserContext } from 'contexts/UserContext';
 import PageWrapper from 'components/basic/pageWrapper';
 import theme from 'styles/theme';
@@ -25,8 +25,8 @@ const NotificationPage = () => {
       const fetchedNotifications = await getNotifications(token);
       setNotifications(
         fetchedNotifications.data.map((notification) => {
-          const { _id } = notification.user;
-          const { fullName } = notification.author;
+          const { userId } = notification.user;
+          const { fullName, image, _id } = notification.author;
           const message =
             (notification.like && '회원님의 게시물에 하트를 눌렀어요') ||
             (notification.comment && '회원님의 게시물에 댓글을 달았어요') ||
@@ -35,28 +35,45 @@ const NotificationPage = () => {
             notificationId: notification._id,
             postId: notification.post,
             message: `님이 ${message}`,
-            userId: _id,
+            userId: userId,
+            authorId: _id,
             isSeen: notification.seen,
             fullName: fullName,
+            img: image,
           };
         }),
       );
     };
     initNotifications();
   }, []);
-
   return (
     <>
       <PageWrapper title="알림" header prev>
         <NotificationsWrapper>
-          {notifications.map(({ notificationId, postId, fullName, message, userId, isSeen }) => (
-            <NotificationCard
-              key={notificationId}
-              isSeen={isSeen}
-              fullName={fullName}
-              message={message}
-            ></NotificationCard>
-          ))}
+          {notifications.map(
+            ({ notificationId, postId, fullName, message, userId, authorId, isSeen, img }) =>
+              postId ? (
+                <Link to={`/post/detail/${postId}`}>
+                  <NotificationCard
+                    key={notificationId}
+                    isSeen={isSeen}
+                    fullName={fullName}
+                    message={message}
+                    img={img}
+                  ></NotificationCard>
+                </Link>
+              ) : (
+                <Link to={`/user/${authorId}`}>
+                  <NotificationCard
+                    key={notificationId}
+                    isSeen={isSeen}
+                    fullName={fullName}
+                    message={message}
+                    img={img}
+                  ></NotificationCard>
+                </Link>
+              ),
+          )}
         </NotificationsWrapper>
       </PageWrapper>
     </>

--- a/src/pages/NotificationPage/index.jsx
+++ b/src/pages/NotificationPage/index.jsx
@@ -40,6 +40,7 @@ const NotificationPage = () => {
             isSeen: notification.seen,
             fullName: fullName,
             img: image,
+            createdAt: notification.createdAt,
           };
         }),
       );
@@ -51,7 +52,17 @@ const NotificationPage = () => {
       <PageWrapper title="알림" header prev>
         <NotificationsWrapper>
           {notifications.map(
-            ({ notificationId, postId, fullName, message, userId, authorId, isSeen, img }) =>
+            ({
+              notificationId,
+              postId,
+              fullName,
+              message,
+              userId,
+              authorId,
+              isSeen,
+              img,
+              createdAt,
+            }) =>
               postId ? (
                 <Link to={`/post/detail/${postId}`}>
                   <NotificationCard
@@ -60,6 +71,7 @@ const NotificationPage = () => {
                     fullName={fullName}
                     message={message}
                     img={img}
+                    createdAt={createdAt}
                   ></NotificationCard>
                 </Link>
               ) : (
@@ -70,6 +82,7 @@ const NotificationPage = () => {
                     fullName={fullName}
                     message={message}
                     img={img}
+                    createdAt={createdAt}
                   ></NotificationCard>
                 </Link>
               ),

--- a/src/pages/NotificationPage/index.jsx
+++ b/src/pages/NotificationPage/index.jsx
@@ -28,8 +28,8 @@ const NotificationPage = () => {
           const { userId } = notification.user;
           const { fullName, image, _id } = notification.author;
           const message =
-            (notification.like && '회원님의 게시물에 하트를 눌렀어요') ||
-            (notification.comment && '회원님의 게시물에 댓글을 달았어요') ||
+            (notification.like && '회원님의 게시물에 하트를 눌렀어요.') ||
+            (notification.comment && '회원님의 게시물에 댓글을 달았어요.') ||
             (notification.follow && '회원님의 계정을 팔로우 했습니다.');
           return {
             notificationId: notification._id,


### PR DESCRIPTION
## ✅ 이슈 번호

## 📌 기능 설명 <!-- 기능을 대략적으로 설명해주세요 -->
1. 프로필 이미지 나오게 구현했습니다.
![image](https://user-images.githubusercontent.com/93373357/174659604-adef28bf-be8d-4fbc-b6f9-3ce4c38b1091.png)

2. 각각 알림을 클릭하는 경우 댓글/좋아요는 그 게시물 링크로, 팔로우는 해당 유저 페이지로 이동하게 하였습니다.
![image](https://user-images.githubusercontent.com/93373357/174660697-f47c4dad-20a2-4160-a4d4-d9b3b8471258.png)

![녹화_2022_06_21_03_25_11_690](https://user-images.githubusercontent.com/93373357/174659917-3a7381c1-f294-49e2-894d-ad731c937780.gif)
(게시물 포스팅 기능 구현 전에 알림을 넣은 것이라 다른 유저의 포스트로 가지만 지금은 해결 되었을거라 추측합니다.)

3. word-break: keep-all 속성 적용해서 한글도 띄어쓰기 단위로 끊어서 줄바꿈 되게 하였습니다.
카드의 padding값도 조정하여 420px, 500px일 때 2줄이 되게 조정하였습니다.
![image](https://user-images.githubusercontent.com/93373357/174660640-4ef3f463-a3bf-44be-a227-abc1a19957aa.png)
![image](https://user-images.githubusercontent.com/93373357/174660208-899ef7ef-afb4-4864-ab71-416a18d333a2.png)
(420px)
![image](https://user-images.githubusercontent.com/93373357/174660283-02f664a9-f92b-4475-ba4d-ff2b8ec56137.png)
(500px)

4. 시간 함수 적용하였습니다.
![image](https://user-images.githubusercontent.com/93373357/174663555-fd68d3b4-fd85-49d3-85a9-139dbfd2691e.png)
![image](https://user-images.githubusercontent.com/93373357/174663587-558c4ec9-48c6-4a12-b515-85b1db65fdc2.png)
