### PR TITLE
feature: 로그인 유지 기능 추가

### DIFF
--- a/src/contexts/UserContext/handles.jsx
+++ b/src/contexts/UserContext/handles.jsx
@@ -17,17 +17,16 @@ const useHandles = () => {
   const [localToken, setLocalToken] = useLocalToken();
   const navigate = useNavigate();
 
-  // 인증된 사용자인 경우, 사용자 정보를 반환받을 수 있다.
   const handleGetCurrentUser = useCallback(async () => {
-    const { data } = await getCurrentUser(localToken);
-    if (!data?._id) {
-      // JWT 토큰 및 로컬 스토리지 초기화
-      alert('인증 실패');
+    const user = await getCurrentUser(localToken).then((res) => res.data);
+    if (!user?._id) {
+      alert('인증에 실패했습니다. 로그인 화면으로 이동합니다.');
       setLocalToken('');
       localStorage.clear();
-      navigate('/login', { replace: true }); // 로그인 화면으로 이동
+      navigate('/login', { replace: true });
+      return;
     }
-    return data;
+    return user;
   }, [navigate, localToken, setLocalToken]);
 
   const handleLogin = useCallback(

--- a/src/contexts/UserContext/index.jsx
+++ b/src/contexts/UserContext/index.jsx
@@ -6,7 +6,7 @@ import {
   LOGIN,
   SIGNUP,
   LOGOUT,
-  GET_CURRENT_USER,
+  KEEP_LOGIN,
   FOLLOW,
   UNFOLLOW,
   LOADING_ON,
@@ -46,18 +46,6 @@ const UserProvider = ({ children }) => {
     handlefollow,
     handleUnFollow,
   } = useHandles();
-
-  // 현재 유저의 정보를 서버로부터 가져온다.
-  const onGetCurrentUser = useCallback(async () => {
-    dispatch({ type: LOADING_ON });
-    if (localToken) {
-      const user = await handleGetCurrentUser();
-      if (user?._id) {
-        dispatch({ type: GET_CURRENT_USER, payload: user }); // 서버에서 받아 온 데이터로 currentUser의 정보 갱신
-      }
-    }
-    dispatch({ type: LOADING_OFF });
-  }, [handleGetCurrentUser, localToken]);
 
   const onLogin = useCallback(
     async (data) => {
@@ -148,6 +136,11 @@ const UserProvider = ({ children }) => {
     dispatch({ type: DISLIKE, payload: like });
   }, []);
 
+  const onKeepLoggedIn = useCallback(async () => {
+    const user = await handleGetCurrentUser();
+    dispatch({ type: KEEP_LOGIN, payload: user });
+  }, [handleGetCurrentUser]);
+
   const value = useMemo(() => {
     return {
       currentUser,
@@ -155,7 +148,6 @@ const UserProvider = ({ children }) => {
       onLogin,
       onSignup,
       onLogout,
-      onGetCurrentUser,
       onFollow,
       onUnfollow,
       onChangeFullName,
@@ -163,6 +155,7 @@ const UserProvider = ({ children }) => {
       onChangePassword,
       onLike,
       onDisLike,
+      onKeepLoggedIn,
     };
   }, [
     currentUser,
@@ -170,7 +163,6 @@ const UserProvider = ({ children }) => {
     onLogin,
     onSignup,
     onLogout,
-    onGetCurrentUser,
     onFollow,
     onUnfollow,
     onChangeFullName,
@@ -178,6 +170,7 @@ const UserProvider = ({ children }) => {
     onChangePassword,
     onLike,
     onDisLike,
+    onKeepLoggedIn,
   ]);
 
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>;

--- a/src/contexts/UserContext/reducer.jsx
+++ b/src/contexts/UserContext/reducer.jsx
@@ -1,8 +1,8 @@
 import {
   LOGIN,
   SIGNUP,
+  KEEP_LOGIN,
   LOGOUT,
-  GET_CURRENT_USER,
   FOLLOW,
   UNFOLLOW,
   LOADING_ON,
@@ -26,13 +26,13 @@ export const initialUserData = {
     following: [],
     notifications: [],
   },
-
   isLoading: false,
 };
 
 export const reducer = (state, { type, payload }) => {
   switch (type) {
     case LOGIN:
+    case KEEP_LOGIN:
     case SIGNUP: {
       return {
         ...state,
@@ -54,22 +54,6 @@ export const reducer = (state, { type, payload }) => {
       return {
         ...state,
         currentUser: { ...initialUserData },
-      };
-    }
-    case GET_CURRENT_USER: {
-      return {
-        ...state,
-        currentUser: {
-          id: payload._id,
-          email: payload.email,
-          fullName: payload.fullName,
-          image: payload.image,
-          posts: payload.posts,
-          followers: payload.followers,
-          following: payload.following,
-          notifications: payload.notifications,
-          likes: payload.likes,
-        },
       };
     }
     case FOLLOW: {

--- a/src/contexts/UserContext/types.jsx
+++ b/src/contexts/UserContext/types.jsx
@@ -1,7 +1,7 @@
 export const LOGIN = 'LOGIN';
+export const KEEP_LOGIN = 'KEEP_LOGIN';
 export const SIGNUP = 'SIGNUP';
 export const LOGOUT = 'LOGOUT';
-export const GET_CURRENT_USER = 'GET_CURRENT_USER';
 export const FOLLOW = 'FOLLOW';
 export const UNFOLLOW = 'UNFOLLOW';
 export const LOADING_ON = 'LOADING_ON';

--- a/src/hooks/useLocalToken.jsx
+++ b/src/hooks/useLocalToken.jsx
@@ -1,5 +1,5 @@
 import useLocalStorage from './useLocalStrorage';
 
-const LOCAL_TOKEN_KEY = 'token';
+const LOCAL_TOKEN_KEY = 'greenButlerUserToken';
 
 export default () => useLocalStorage(LOCAL_TOKEN_KEY, '');

--- a/src/pages/MainPage/PostBody.jsx
+++ b/src/pages/MainPage/PostBody.jsx
@@ -74,7 +74,7 @@ const PostBody = ({ post, isDetailPage = false }) => {
     postId,
     likeId,
     author._id,
-    currentUser.id,
+    currentUser,
     localToken,
     onLike,
     onDisLike,
@@ -93,7 +93,7 @@ const PostBody = ({ post, isDetailPage = false }) => {
       setOnHeart(true);
       setLikeId(likeId);
     }
-  }, []);
+  }, [currentUser, likes]);
 
   const handleMoreClick = () => {
     setIsShown(true);

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -1,12 +1,13 @@
-import { Routes, Route } from 'react-router-dom';
+import { useEffect } from 'react';
+import useLocalToken from 'hooks/useLocalToken';
+import { Routes, Route, useNavigate } from 'react-router-dom';
+import { useUserContext } from 'contexts/UserContext';
 import {
   LoginPage,
   SignupPage,
   MainPage,
-  PostAddPage,
   PostEditPage,
   PostDetailPage,
-  MyPage,
   UserPage,
   FollowPage,
   MyInfoPage,
@@ -18,6 +19,18 @@ import {
 } from '../pages/index';
 
 const Router = () => {
+  const navigate = useNavigate();
+  const [token] = useLocalToken();
+  const { onKeepLoggedIn } = useUserContext();
+
+  useEffect(() => {
+    if (!token) {
+      navigate('/login', { replace: true });
+      return;
+    }
+    onKeepLoggedIn();
+  }, []);
+
   return (
     <Routes>
       <Route path="/login" element={<LoginPage />} />


### PR DESCRIPTION
## ✅ 이슈 번호
#153 

## 📌 기능 설명 <!-- 기능을 대략적으로 설명해주세요 -->
1. 새로고침 또는 url을 직접 변경 시 로그아웃 되는 현상이 발생합니다.
이에 로그인을 유지하는 기능을 추가했습니다. 

2. 명시적으로 로그아웃 하지 않는 한,
    앱을 리부팅해도 자동으로 로그인 하는 기능을 추가했습니다. 

3. 로컬 스토리지에 저장되는 토큰의 key를 
   `token`에서 `greenButlerUserToken`으로 변경했습니다. 
   기존의 `token`은 너무 일반적인 명칭이기 때문입니다. 

## 구현 내용

![image](https://user-images.githubusercontent.com/80658269/174723135-d2df6580-162e-4251-9b75-11fceb45f53d.png)

Router 컴포넌트 내에 다음과 같은 코드를 삽입했습니다. 

![image](https://user-images.githubusercontent.com/80658269/174723499-cce9b04e-7c4d-48a0-84be-23e8e4bd52a9.png)

로컬 스토리지에 토큰이 없으면 로그인 화면으로 이동시키고, 
토큰이 있으면 `onKeepLoggedIn` 함수를 실행합니다. 

`onKeepLoggedIn` 함수는 UserContext의 전역 함수입니다. 

![image](https://user-images.githubusercontent.com/80658269/174723776-4049b869-7d32-4a9e-952f-ec683c02f7cb.png)

토큰으로 유저의 정보를 서버에서 가져온 뒤, 
currentUser의 데이터를 갱신합니다. 

결과적으로 유저의 정보를 이전과 같이 유지할 수 있게 됩니다. 

## 구현 결과
새로고침을 하거나, url을 변경해도 로그인 상태가 유지되는 것을 볼 수 있습니다. 

https://user-images.githubusercontent.com/80658269/174724492-a56b8648-79fa-4f60-bf00-cab0395cf7a7.mp4


## 알아둘 점
- 프론트엔드 측에서는 로그인을 유지한 것이지만, 
  서버측에서는 이를 로그인한 상태로 볼 지, 아닐지는 확실하지 않습니다. 

  이메일과 패스워드를 입력하여 로그인을 한 것이 아니기 때문입니다. 
  서버가 이를 로그인한 상태로 볼 지는 미지수입니다. 

- 나중에는 세션 스토리지를 사용하여
  자동 로그인이 아닌 일회성 로그인으로 바꾸어 볼 생각입니다. 

피드백 주시면 감사하겠습니다 :)
