### PR TITLE
Feature: 유저 정보 페이지에 유저 활동 점수 및 등급 확인 기능 추가

### DIFF
--- a/src/pages/MyInfoPage/LevelModal.jsx
+++ b/src/pages/MyInfoPage/LevelModal.jsx
@@ -1,0 +1,101 @@
+import Icon from 'components/basic/Icon';
+import Text from 'components/basic/Text';
+import levels from 'utils/functions/userLevel/levels';
+import styled from '@emotion/styled';
+import Avatar from 'components/basic/Avatar';
+import theme from 'styles/theme';
+
+const { fontNormal, fontBlack, backgroundLight, fontDark } = theme.color;
+
+const ModalContainer = styled.div`
+  width: 100%;
+  background-color: white;
+  max-width: 370px;
+  border-radius: 15px;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 20px 25px;
+`;
+
+const CloseButton = styled(Icon.Button)`
+  position: absolute;
+  right: 20px;
+`;
+
+const ScoreDescription = styled.div`
+  font-size: 14px;
+  background-color: ${backgroundLight};
+  border-radius: 10px;
+  padding: 16px;
+  line-height: 24px;
+  margin-top: 20px;
+  color: ${fontDark};
+`;
+const LevelList = styled.ul`
+  margin: 20px 0 20px;
+
+  li:not(:first-of-type) {
+    margin-top: 20px;
+  }
+`;
+
+const LevelItem = styled.li`
+  display: flex;
+  align-items: center;
+`;
+
+const LevelInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 18px;
+`;
+const LevelName = styled.span`
+  font-size: 16px;
+  font-weight: bold;
+`;
+const LevelDescription = styled.span`
+  font-size: 14px;
+  margin-top: 8px;
+  color: ${fontNormal};
+`;
+const Strong = styled.span`
+  font-weight: bold;
+  color: ${fontBlack};
+`;
+const LevelModal = ({ onClose }) => {
+  return (
+    <ModalContainer>
+      <CloseButton name="CLOSE" size={30} onClick={onClose} />
+      <Text fontSize={22} block strong style={{ marginTop: 30 }}>
+        활동 점수
+      </Text>
+      <Text block fontSize={16} style={{ marginTop: 12 }}>
+        활동 점수에 따라 등급이 부여됩니다.
+      </Text>
+      <ScoreDescription>
+        게시물 등록 시 <Strong>+2점</Strong>, 댓글 등록 시 <Strong>+1점</Strong>,<br />
+        다른 사람이 나를 팔로우 할 시 <Strong>+1점</Strong>
+      </ScoreDescription>
+      <LevelList>
+        {levels.map((level, index) => (
+          <LevelItem key={index}>
+            <Avatar
+              src={level.image}
+              size={50}
+              alt={level.name}
+              style={{ backgroundColor: level.color, border: 0 }}
+            />
+            <LevelInfo>
+              <LevelName>{level.name}</LevelName>
+              <LevelDescription>{level.description}</LevelDescription>
+            </LevelInfo>
+          </LevelItem>
+        ))}
+      </LevelList>
+    </ModalContainer>
+  );
+};
+
+export default LevelModal;

--- a/src/pages/MyInfoPage/UserLevel.jsx
+++ b/src/pages/MyInfoPage/UserLevel.jsx
@@ -1,0 +1,91 @@
+import Icon from 'components/basic/Icon';
+import Text from 'components/basic/Text';
+import levels from 'utils/functions/userLevel/levels';
+import styled from '@emotion/styled';
+import theme from 'styles/theme';
+
+const { mainGreen, mainWhite, fontNormal } = theme.color;
+
+const LevelContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  margin-top: 40px;
+  margin-bottom: 30px;
+`;
+
+const MyLevel = styled.div`
+  background-color: ${mainGreen};
+  width: 150px;
+  text-align: center;
+  padding: 10px;
+  border-radius: 15px;
+  color: ${mainWhite};
+  font-size: 18px;
+  position: absolute;
+  top: -16px;
+`;
+
+const MyHistory = styled.ul`
+  width: 80%;
+  display: flex;
+  background-color: #f0f9f7;
+  border-radius: 15px;
+  padding: 25px;
+  justify-content: space-around;
+`;
+
+const HistoryItem = styled.li`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 16px;
+`;
+
+const HistoryTitle = styled.span`
+  font-size: 16px;
+  color: ${fontNormal};
+`;
+
+const HistoryCount = styled.span`
+  font-size: 20px;
+  font-weight: 600;
+  color: ${mainGreen};
+  margin-top: 10px;
+`;
+
+const CurrentScore = styled(Text)`
+  margin-top: 24px;
+`;
+
+const UserLevel = () => {
+  return (
+    <LevelContainer>
+      <MyLevel>초록집사</MyLevel>
+      <MyHistory>
+        <HistoryItem>
+          <HistoryTitle>게시글</HistoryTitle>
+          <HistoryCount>0</HistoryCount>
+        </HistoryItem>
+        <HistoryItem>
+          <HistoryTitle>댓글</HistoryTitle>
+          <HistoryCount>0</HistoryCount>
+        </HistoryItem>
+        <HistoryItem>
+          <HistoryTitle>좋아요</HistoryTitle>
+          <HistoryCount>0</HistoryCount>
+        </HistoryItem>
+      </MyHistory>
+
+      <CurrentScore fontSize={16} block>
+        현재 활동 점수 :
+        <Text fontSize={16} strong>
+          10
+        </Text>
+      </CurrentScore>
+    </LevelContainer>
+  );
+};
+
+export default UserLevel;

--- a/src/pages/MyInfoPage/UserLevel.jsx
+++ b/src/pages/MyInfoPage/UserLevel.jsx
@@ -3,8 +3,16 @@ import Text from 'components/basic/Text';
 import levels from 'utils/functions/userLevel/levels';
 import styled from '@emotion/styled';
 import theme from 'styles/theme';
+import { useEffect } from 'react';
+import { getUser } from 'utils/apis/userApi';
+import { useUserContext } from 'contexts/UserContext';
+import { useState } from 'react';
+import Image from 'components/basic/Image';
+import Modal from 'components/Modal';
+import Profile from 'components/Profile';
+import Avatar from 'components/basic/Avatar';
 
-const { mainGreen, mainWhite, fontNormal } = theme.color;
+const { mainGreen, mainWhite, fontNormal, fontBlack, backgroundLight, fontDark } = theme.color;
 
 const LevelContainer = styled.div`
   display: flex;
@@ -12,26 +20,28 @@ const LevelContainer = styled.div`
   align-items: center;
   position: relative;
   margin-top: 40px;
-  margin-bottom: 30px;
+  margin-bottom: 50px;
 `;
 
 const MyLevel = styled.div`
-  background-color: ${mainGreen};
-  width: 150px;
-  text-align: center;
-  padding: 10px;
-  border-radius: 15px;
-  color: ${mainWhite};
-  font-size: 18px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 8px 20px;
   position: absolute;
   top: -16px;
+  font-size: 18px;
+  text-align: center;
+  color: ${mainWhite};
+  border-radius: 30px;
+  background-color: ${mainGreen};
 `;
 
 const MyHistory = styled.ul`
   width: 80%;
   display: flex;
   background-color: #f0f9f7;
-  border-radius: 15px;
+  border-radius: 30px;
   padding: 25px;
   justify-content: space-around;
 `;
@@ -57,33 +67,193 @@ const HistoryCount = styled.span`
 
 const CurrentScore = styled(Text)`
   margin-top: 24px;
+  cursor: pointer;
+`;
+
+const LevelIcon = styled.div`
+  width: 25px;
+  height: 25px;
+  margin-right: 5px;
+  background-color: white;
+  background-image: url(https://user-images.githubusercontent.com/81489300/174669864-832f9df6-7ae6-41c1-93df-1e9d4b6e50bb.svg);
+  background-size: 80%;
+  background-position: center;
+  background-repeat: no-repeat;
+  border-radius: 15px;
+`;
+
+const Strong = styled.span`
+  font-weight: bold;
+  color: ${fontBlack};
+`;
+
+const LevelModal = styled.div`
+  width: 100%;
+  background-color: white;
+  max-width: 370px;
+  border-radius: 15px;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 20px 25px;
+`;
+
+const CloseButton = styled(Icon.Button)`
+  position: absolute;
+  right: 20px;
+`;
+
+const ScoreDescription = styled.div`
+  font-size: 14px;
+  background-color: ${backgroundLight};
+  border-radius: 10px;
+  padding: 16px;
+  line-height: 24px;
+  margin-top: 20px;
+  color: ${fontDark};
+`;
+const LevelList = styled.ul`
+  margin: 20px 0 20px;
+
+  li:not(:first-of-type) {
+    margin-top: 20px;
+  }
+`;
+
+const LevelItem = styled.li`
+  display: flex;
+  align-items: center;
+`;
+
+const LevelInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 18px;
+`;
+const LevelName = styled.span`
+  font-size: 16px;
+  font-weight: bold;
+`;
+const LevelDescription = styled.span`
+  font-size: 14px;
+  margin-top: 8px;
+  color: ${fontNormal};
 `;
 
 const UserLevel = () => {
+  const { currentUser } = useUserContext();
+  const [userData, setUserData] = useState({ post: 0, comment: 0, follower: 0 });
+  const [isModal, setIsModal] = useState(false);
+
+  const getUserInfo = async (userId) => {
+    const result = await getUser(userId).then((res) => res.data);
+    setUserData({
+      post: result.posts.length,
+      comment: result.comments.length,
+      follower: result.followers.length,
+    });
+    console.log(result);
+  };
+
+  const closeModal = () => {
+    setIsModal(false);
+  };
+
+  useEffect(() => {
+    if (currentUser.id) {
+      getUserInfo(currentUser.id);
+    }
+  }, [currentUser.id]);
+
   return (
     <LevelContainer>
-      <MyLevel>초록집사</MyLevel>
+      <MyLevel>
+        <LevelIcon />
+        초록집사
+      </MyLevel>
       <MyHistory>
         <HistoryItem>
           <HistoryTitle>게시글</HistoryTitle>
-          <HistoryCount>0</HistoryCount>
+          <HistoryCount>{userData.post}</HistoryCount>
         </HistoryItem>
         <HistoryItem>
           <HistoryTitle>댓글</HistoryTitle>
-          <HistoryCount>0</HistoryCount>
+          <HistoryCount>{userData.comment}</HistoryCount>
         </HistoryItem>
         <HistoryItem>
-          <HistoryTitle>좋아요</HistoryTitle>
-          <HistoryCount>0</HistoryCount>
+          <HistoryTitle>팔로워</HistoryTitle>
+          <HistoryCount>{userData.follower}</HistoryCount>
         </HistoryItem>
       </MyHistory>
 
       <CurrentScore fontSize={16} block>
-        현재 활동 점수 :
-        <Text fontSize={16} strong>
-          10
+        <Text color={fontBlack} fontSize={16} underline onClick={() => setIsModal(true)}>
+          현재 활동 점수
+        </Text>
+        :
+        <Text fontSize={16} strong style={{ marginLeft: 5 }}>
+          999
         </Text>
       </CurrentScore>
+      <Modal visible={isModal} onClose={closeModal}>
+        <Modal.Custom>
+          <LevelModal>
+            <CloseButton name="CLOSE" size={30} onClick={closeModal} />
+            <Text fontSize={22} block strong style={{ marginTop: 30 }}>
+              활동 점수
+            </Text>
+            <Text block fontSize={16} style={{ marginTop: 12 }}>
+              활동 점수에 따라 등급이 부여됩니다.
+            </Text>
+            <ScoreDescription>
+              게시물 등록 시 <Strong>+2점</Strong>, 댓글 등록 시 <Strong>+1점</Strong>,<br />
+              다른 사람이 나를 팔로우 할 시 <Strong>+1점</Strong>
+            </ScoreDescription>
+            <LevelList>
+              <LevelItem>
+                <Avatar src={levels.one.image} size={50} alt="Level1" />
+                <LevelInfo>
+                  <LevelName>{levels.one.name}</LevelName>
+                  <LevelDescription>{levels.one.description}</LevelDescription>
+                </LevelInfo>
+              </LevelItem>
+
+              <LevelItem>
+                <Avatar src={levels.two.image} size={50} alt="Level1" />
+                <LevelInfo>
+                  <LevelName>{levels.two.name}</LevelName>
+                  <LevelDescription>{levels.two.description}</LevelDescription>
+                </LevelInfo>
+              </LevelItem>
+
+              <LevelItem>
+                <Avatar src={levels.three.image} size={50} alt="Level1" />
+                <LevelInfo>
+                  <LevelName>{levels.three.name}</LevelName>
+                  <LevelDescription>{levels.three.description}</LevelDescription>
+                </LevelInfo>
+              </LevelItem>
+
+              <LevelItem>
+                <Avatar src={levels.four.image} size={50} alt="Level1" />
+                <LevelInfo>
+                  <LevelName>{levels.four.name}</LevelName>
+                  <LevelDescription>{levels.four.description}</LevelDescription>
+                </LevelInfo>
+              </LevelItem>
+
+              <LevelItem>
+                <Avatar src={levels.five.image} size={50} alt="Level1" />
+                <LevelInfo>
+                  <LevelName>{levels.five.name}</LevelName>
+                  <LevelDescription>{levels.five.description}</LevelDescription>
+                </LevelInfo>
+              </LevelItem>
+            </LevelList>
+          </LevelModal>
+        </Modal.Custom>
+      </Modal>
     </LevelContainer>
   );
 };

--- a/src/pages/MyInfoPage/UserLevel.jsx
+++ b/src/pages/MyInfoPage/UserLevel.jsx
@@ -1,19 +1,16 @@
-import Icon from 'components/basic/Icon';
 import Text from 'components/basic/Text';
-import levels from 'utils/functions/userLevel/levels';
 import styled from '@emotion/styled';
 import theme from 'styles/theme';
 import { useEffect } from 'react';
 import { getUser } from 'utils/apis/userApi';
 import { useUserContext } from 'contexts/UserContext';
 import { useState } from 'react';
-import Image from 'components/basic/Image';
 import Modal from 'components/Modal';
-import Profile from 'components/Profile';
-import Avatar from 'components/basic/Avatar';
 import getUserLevel from 'utils/functions/userLevel/getUserLevel';
+import { useCallback } from 'react';
+import LevelModal from './LevelModal';
 
-const { mainGreen, mainWhite, fontNormal, fontBlack, backgroundLight, fontDark } = theme.color;
+const { mainGreen, mainWhite, fontNormal, fontBlack } = theme.color;
 
 const LevelContainer = styled.div`
   display: flex;
@@ -83,65 +80,6 @@ const LevelIcon = styled.div`
   border-radius: 15px;
 `;
 
-const Strong = styled.span`
-  font-weight: bold;
-  color: ${fontBlack};
-`;
-
-const LevelModal = styled.div`
-  width: 100%;
-  background-color: white;
-  max-width: 370px;
-  border-radius: 15px;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  padding: 20px 25px;
-`;
-
-const CloseButton = styled(Icon.Button)`
-  position: absolute;
-  right: 20px;
-`;
-
-const ScoreDescription = styled.div`
-  font-size: 14px;
-  background-color: ${backgroundLight};
-  border-radius: 10px;
-  padding: 16px;
-  line-height: 24px;
-  margin-top: 20px;
-  color: ${fontDark};
-`;
-const LevelList = styled.ul`
-  margin: 20px 0 20px;
-
-  li:not(:first-of-type) {
-    margin-top: 20px;
-  }
-`;
-
-const LevelItem = styled.li`
-  display: flex;
-  align-items: center;
-`;
-
-const LevelInfo = styled.div`
-  display: flex;
-  flex-direction: column;
-  margin-left: 18px;
-`;
-const LevelName = styled.span`
-  font-size: 16px;
-  font-weight: bold;
-`;
-const LevelDescription = styled.span`
-  font-size: 14px;
-  margin-top: 8px;
-  color: ${fontNormal};
-`;
-
 const UserLevel = () => {
   const { currentUser } = useUserContext();
   const [userData, setUserData] = useState({
@@ -171,9 +109,9 @@ const UserLevel = () => {
     });
   };
 
-  const closeModal = () => {
+  const closeModal = useCallback(() => {
     setIsModal(false);
-  };
+  }, []);
 
   useEffect(() => {
     if (currentUser.id) {
@@ -185,7 +123,7 @@ const UserLevel = () => {
     <LevelContainer>
       {userData.currentLevel && (
         <MyLevel>
-          userData.currentLevel && <LevelIcon src={userData.currentLevel.image} />
+          <LevelIcon src={userData.currentLevel.image} />
           {userData.currentLevel?.name}
         </MyLevel>
       )}
@@ -215,35 +153,7 @@ const UserLevel = () => {
       </CurrentScore>
       <Modal visible={isModal} onClose={closeModal}>
         <Modal.Custom>
-          <LevelModal>
-            <CloseButton name="CLOSE" size={30} onClick={closeModal} />
-            <Text fontSize={22} block strong style={{ marginTop: 30 }}>
-              활동 점수
-            </Text>
-            <Text block fontSize={16} style={{ marginTop: 12 }}>
-              활동 점수에 따라 등급이 부여됩니다.
-            </Text>
-            <ScoreDescription>
-              게시물 등록 시 <Strong>+2점</Strong>, 댓글 등록 시 <Strong>+1점</Strong>,<br />
-              다른 사람이 나를 팔로우 할 시 <Strong>+1점</Strong>
-            </ScoreDescription>
-            <LevelList>
-              {levels.map((level, index) => (
-                <LevelItem key={index}>
-                  <Avatar
-                    src={level.image}
-                    size={50}
-                    alt={level.name}
-                    style={{ backgroundColor: level.color, border: 0 }}
-                  />
-                  <LevelInfo>
-                    <LevelName>{level.name}</LevelName>
-                    <LevelDescription>{level.description}</LevelDescription>
-                  </LevelInfo>
-                </LevelItem>
-              ))}
-            </LevelList>
-          </LevelModal>
+          <LevelModal onClose={closeModal} />
         </Modal.Custom>
       </Modal>
     </LevelContainer>

--- a/src/pages/MyInfoPage/UserLevel.jsx
+++ b/src/pages/MyInfoPage/UserLevel.jsx
@@ -1,6 +1,6 @@
 import Icon from 'components/basic/Icon';
 import Text from 'components/basic/Text';
-import levels from 'utils/functions/userLevel/levels';
+import { levels } from 'utils/functions/userLevel/levels';
 import styled from '@emotion/styled';
 import theme from 'styles/theme';
 import { useEffect } from 'react';
@@ -211,45 +211,20 @@ const UserLevel = () => {
               다른 사람이 나를 팔로우 할 시 <Strong>+1점</Strong>
             </ScoreDescription>
             <LevelList>
-              <LevelItem>
-                <Avatar src={levels.one.image} size={50} alt="Level1" />
-                <LevelInfo>
-                  <LevelName>{levels.one.name}</LevelName>
-                  <LevelDescription>{levels.one.description}</LevelDescription>
-                </LevelInfo>
-              </LevelItem>
-
-              <LevelItem>
-                <Avatar src={levels.two.image} size={50} alt="Level1" />
-                <LevelInfo>
-                  <LevelName>{levels.two.name}</LevelName>
-                  <LevelDescription>{levels.two.description}</LevelDescription>
-                </LevelInfo>
-              </LevelItem>
-
-              <LevelItem>
-                <Avatar src={levels.three.image} size={50} alt="Level1" />
-                <LevelInfo>
-                  <LevelName>{levels.three.name}</LevelName>
-                  <LevelDescription>{levels.three.description}</LevelDescription>
-                </LevelInfo>
-              </LevelItem>
-
-              <LevelItem>
-                <Avatar src={levels.four.image} size={50} alt="Level1" />
-                <LevelInfo>
-                  <LevelName>{levels.four.name}</LevelName>
-                  <LevelDescription>{levels.four.description}</LevelDescription>
-                </LevelInfo>
-              </LevelItem>
-
-              <LevelItem>
-                <Avatar src={levels.five.image} size={50} alt="Level1" />
-                <LevelInfo>
-                  <LevelName>{levels.five.name}</LevelName>
-                  <LevelDescription>{levels.five.description}</LevelDescription>
-                </LevelInfo>
-              </LevelItem>
+              {levels.map((level, index) => (
+                <LevelItem key={index}>
+                  <Avatar
+                    src={level.image}
+                    size={50}
+                    alt={level.name}
+                    style={{ backgroundColor: level.color, border: 0 }}
+                  />
+                  <LevelInfo>
+                    <LevelName>{level.name}</LevelName>
+                    <LevelDescription>{level.description}</LevelDescription>
+                  </LevelInfo>
+                </LevelItem>
+              ))}
             </LevelList>
           </LevelModal>
         </Modal.Custom>

--- a/src/pages/MyInfoPage/UserLevel.jsx
+++ b/src/pages/MyInfoPage/UserLevel.jsx
@@ -1,6 +1,6 @@
 import Icon from 'components/basic/Icon';
 import Text from 'components/basic/Text';
-import { levels } from 'utils/functions/userLevel/levels';
+import levels from 'utils/functions/userLevel/levels';
 import styled from '@emotion/styled';
 import theme from 'styles/theme';
 import { useEffect } from 'react';
@@ -11,6 +11,7 @@ import Image from 'components/basic/Image';
 import Modal from 'components/Modal';
 import Profile from 'components/Profile';
 import Avatar from 'components/basic/Avatar';
+import getUserLevel from 'utils/functions/userLevel/getUserLevel';
 
 const { mainGreen, mainWhite, fontNormal, fontBlack, backgroundLight, fontDark } = theme.color;
 
@@ -75,7 +76,7 @@ const LevelIcon = styled.div`
   height: 25px;
   margin-right: 5px;
   background-color: white;
-  background-image: url(https://user-images.githubusercontent.com/81489300/174669864-832f9df6-7ae6-41c1-93df-1e9d4b6e50bb.svg);
+  background-image: ${({ src }) => src && `URL(${src})`};
   background-size: 80%;
   background-position: center;
   background-repeat: no-repeat;
@@ -143,17 +144,31 @@ const LevelDescription = styled.span`
 
 const UserLevel = () => {
   const { currentUser } = useUserContext();
-  const [userData, setUserData] = useState({ post: 0, comment: 0, follower: 0 });
+  const [userData, setUserData] = useState({
+    post: 0,
+    comment: 0,
+    follower: 0,
+    currentLevel: null,
+    currentScore: 0,
+  });
+
   const [isModal, setIsModal] = useState(false);
 
   const getUserInfo = async (userId) => {
     const result = await getUser(userId).then((res) => res.data);
+    const { score, level } = getUserLevel({
+      posts: result.posts,
+      comments: result.comments,
+      followers: result.followers,
+    });
+
     setUserData({
       post: result.posts.length,
       comment: result.comments.length,
       follower: result.followers.length,
+      currentLevel: level,
+      currentScore: score,
     });
-    console.log(result);
   };
 
   const closeModal = () => {
@@ -168,10 +183,12 @@ const UserLevel = () => {
 
   return (
     <LevelContainer>
-      <MyLevel>
-        <LevelIcon />
-        초록집사
-      </MyLevel>
+      {userData.currentLevel && (
+        <MyLevel>
+          userData.currentLevel && <LevelIcon src={userData.currentLevel.image} />
+          {userData.currentLevel?.name}
+        </MyLevel>
+      )}
       <MyHistory>
         <HistoryItem>
           <HistoryTitle>게시글</HistoryTitle>
@@ -193,7 +210,7 @@ const UserLevel = () => {
         </Text>
         :
         <Text fontSize={16} strong style={{ marginLeft: 5 }}>
-          999
+          {userData.currentScore}
         </Text>
       </CurrentScore>
       <Modal visible={isModal} onClose={closeModal}>

--- a/src/pages/MyInfoPage/index.jsx
+++ b/src/pages/MyInfoPage/index.jsx
@@ -2,21 +2,23 @@ import styled from '@emotion/styled';
 import PageWrapper from 'components/basic/pageWrapper';
 import UserDetails from './UserDetails';
 import UserProfile from './UserProfile';
+import UserLevel from './UserLevel';
 
 const MyInfoPage = () => {
   return (
     <PageWrapper header prev title="내정보">
-      <UserContainter>
+      <UserContainer>
         <UserProfile />
+        <UserLevel />
         <UserDetails />
-      </UserContainter>
+      </UserContainer>
     </PageWrapper>
   );
 };
 
 export default MyInfoPage;
 
-const UserContainter = styled.div`
+const UserContainer = styled.div`
   width: 100%;
   height: 100%;
   position: relative;

--- a/src/utils/constants/icons/index.js
+++ b/src/utils/constants/icons/index.js
@@ -42,4 +42,6 @@ export const ICON_TYPES = {
   HEART_ACTIVE:
     'https://user-images.githubusercontent.com/81489300/174609980-c2ba0e09-6c31-4437-8e2d-c67bcb323e9e.svg',
   MORE: 'https://user-images.githubusercontent.com/81489300/173678702-f33d6b86-fc17-4d08-8d3f-fc11d7abd791.svg',
+  CLOSE:
+    'https://user-images.githubusercontent.com/81489300/174680711-d171d380-f02c-4afe-8d60-7f5ef2d9d821.svg',
 };

--- a/src/utils/functions/userLevel/getUserLevel.js
+++ b/src/utils/functions/userLevel/getUserLevel.js
@@ -12,23 +12,23 @@ import levels from './levels';
     4) 식물마스터: 점수 250 이상 500 미만
     5) 태양신: 점수 500 이상
 */
-export default function getUserLevel({ posts, comments }) {
-  const score = 2 * posts.length + comments.length + getLikeCount(posts);
+export default function getUserLevel({ posts, comments, followers }) {
+  const score = 2 * posts.length + comments.length + followers.length;
   let level;
   if (score >= 0 && score < 30) {
-    level = levels.one;
+    level = levels[0];
   }
   if (score >= 30 && score < 100) {
-    level = levels.two;
+    level = levels[1];
   }
   if (score >= 100 && score < 250) {
-    level = levels.three;
+    level = levels[2];
   }
   if (score >= 250 && score < 500) {
-    level = levels.four;
+    level = levels[3];
   }
   if (score >= 500) {
-    level = levels.five;
+    level = levels[4];
   }
   return {
     score,

--- a/src/utils/functions/userLevel/levels.js
+++ b/src/utils/functions/userLevel/levels.js
@@ -5,3 +5,41 @@ export default {
   four: '식물마스터',
   five: '태양신',
 };
+
+export const levels = [
+  {
+    name: '초린이',
+    image:
+      'https://user-images.githubusercontent.com/81489300/174682203-92cd2e52-232f-442d-b2ea-3ca3beb88d09.png',
+    description: '활동 점수 0 이상 30 미만',
+    color: '#F2F9D7',
+  },
+  {
+    name: '초록집사',
+    image:
+      'https://user-images.githubusercontent.com/81489300/174682206-33218082-6277-4bbb-96ad-ad699a950129.png',
+    description: '활동 점수 30 이상 100 미만',
+    color: '#D7EFCE',
+  },
+  {
+    name: '초록현자',
+    image:
+      'https://user-images.githubusercontent.com/81489300/174682209-1bbee0de-c329-41b6-a9e5-ef62da5f850a.png',
+    description: '활동 점수 100 이상 250 미만',
+    color: '#FFDEC7',
+  },
+  {
+    name: '식물마스터',
+    image:
+      'https://user-images.githubusercontent.com/81489300/174682210-94472dd4-1918-4e1c-9345-303b8202d4b9.png',
+    description: '활동 점수 250 이상 500 미만',
+    color: '#CEEDED',
+  },
+  {
+    name: '태양신',
+    image:
+      'https://user-images.githubusercontent.com/81489300/174682212-41a1233f-0c3e-4bd4-bcc1-ad3e5109ee0e.png',
+    description: '활동 점수 500 이상',
+    color: '#FFF8D9',
+  },
+];

--- a/src/utils/functions/userLevel/levels.js
+++ b/src/utils/functions/userLevel/levels.js
@@ -1,12 +1,4 @@
-export default {
-  one: '초린이',
-  two: '초록집사',
-  three: '초록현자',
-  four: '식물마스터',
-  five: '태양신',
-};
-
-export const levels = [
+export default [
   {
     name: '초린이',
     image:


### PR DESCRIPTION
## PR 템플릿
## ✅ 이슈 번호

## 📌 기능 설명 <!-- 기능을 대략적으로 설명해주세요 -->

- 유저 정보페이지에 유저의 활동 내역과 활동 점수를 추가했습니다.
![image](https://user-images.githubusercontent.com/81489300/174734958-f1397bb6-2692-4f7b-95ad-c5abfa4e14fd.png)

- 유저 정보 페이지 접근 시 서버에서 유저의 정보를 가져옵니다
![image](https://user-images.githubusercontent.com/81489300/174735148-f06d95ef-11e3-48d0-8efa-fff4f6fa09a1.png)

- 유저 정보 페이지의 현재 활동 점수를 클릭하면 아래와 같은 모달이 나타납니다.
![image](https://user-images.githubusercontent.com/81489300/174735254-7b30d5f3-c054-4933-bd58-b36304e67937.png)

- 유저 등급에 관한 내용을 한곳에서 처리하도록 변경했습니다.
![image](https://user-images.githubusercontent.com/81489300/174735690-6627c5f9-09e8-488f-8a74-38e5c0c729c5.png)

- 수정이나 개선할 부분이 있다면 코멘트 부탁드립니다.