### PR TITLE
hotfix: .HEIC 이미지 로드 에러 수정

### DIFF
--- a/src/components/PostImageContainer/index.jsx
+++ b/src/components/PostImageContainer/index.jsx
@@ -26,6 +26,7 @@ const PostImageContainer = React.memo(function ImageContainer({ posts }) {
             threshold={0.4}
             placeholder={IMAGE_URLS.POST_DEFAULT_IMG}
             style={{ position: 'absolute', left: 0, top: 0 }}
+            defaultImageUrl={IMAGE_URLS.POST_DEFAULT_GRID_IMG}
           />
         </ImageItem>
       ))}

--- a/src/components/basic/Avatar/index.jsx
+++ b/src/components/basic/Avatar/index.jsx
@@ -48,6 +48,7 @@ const Avatar = ({
         mode="cover"
         placeholder={placeholder}
         style={{ opacity: loaded ? 1 : 0 }}
+        defaultImageUrl={IMAGE_URLS.PROFILE_IMG}
       />
     </AvatarWrapper>
   );

--- a/src/components/basic/Image/index.jsx
+++ b/src/components/basic/Image/index.jsx
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
+import { useCallback } from 'react';
 import { useState, useRef, useEffect } from 'react';
+import { IMAGE_URLS } from 'utils/constants/images';
 
 let observer = null;
 const LOAD_IMG_EVENT_TYPE = 'loadImage';
@@ -57,6 +59,19 @@ const Image = ({
     imgRef.current && observer.observe(imgRef.current);
   }, [lazy, threshold]);
 
+  const handleError = useCallback(
+    ({ target }) => {
+      target.onerror = null;
+      if (alt === '유저 프로필 이미지') {
+        target.src = IMAGE_URLS.PROFILE_IMG;
+        target.style.opacity = 1;
+      } else {
+        target.src = IMAGE_URLS.POST_DEFAULT_IMG;
+      }
+    },
+    [alt],
+  );
+
   return (
     <img
       ref={imgRef}
@@ -65,6 +80,7 @@ const Image = ({
       width={width}
       height={height}
       style={{ ...props.style, ...imageStyle }}
+      onError={handleError}
     />
   );
 };

--- a/src/components/basic/Image/index.jsx
+++ b/src/components/basic/Image/index.jsx
@@ -25,6 +25,7 @@ const Image = ({
   height,
   alt,
   mode = 'cover',
+  defaultImageUrl,
   ...props
 }) => {
   const [loaded, setLoaded] = useState(false);
@@ -62,14 +63,10 @@ const Image = ({
   const handleError = useCallback(
     ({ target }) => {
       target.onerror = null;
-      if (alt === '유저 프로필 이미지') {
-        target.src = IMAGE_URLS.PROFILE_IMG;
-        target.style.opacity = 1;
-      } else {
-        target.src = IMAGE_URLS.POST_DEFAULT_IMG;
-      }
+      target.src = defaultImageUrl || '';
+      target.style.opacity = 1;
     },
-    [alt],
+    [defaultImageUrl],
   );
 
   return (

--- a/src/pages/MainPage/PostBody.jsx
+++ b/src/pages/MainPage/PostBody.jsx
@@ -88,7 +88,12 @@ const PostBody = ({ post, isDetailPage = false }) => {
   return (
     <Container>
       <ImageWrapper onClick={handleTodetailpage} isDetailPage={isDetailPage}>
-        <Image src={image ? image : IMAGE_URLS.POST_DEFAULT_IMG} width="100%" height="100%" />
+        <Image
+          src={image ? image : IMAGE_URLS.POST_DEFAULT_IMG}
+          defaultImageUrl={IMAGE_URLS.POST_DEFAULT_IMG}
+          width="100%"
+          height="100%"
+        />
       </ImageWrapper>
       <Contents>
         <IconButtons>


### PR DESCRIPTION
## ✅ 이슈 번호
#181 

## 📌 기능 설명 <!-- 기능을 대략적으로 설명해주세요 -->
- .HEIC 확장자로 이미지 등록 시 로드 에러가 발생합니다. 
          엑박 이미지가 나타나 보기 좋지 못합니다. 
- 로드 에러 시, 엑박 이미지가 아닌 디폴트 이미지로 대체해 보여주었습니다. 

## 👩‍💻 구현 내용 
Image 컴포넌트에 handleError 함수를 추가했습니다. 
![image](https://user-images.githubusercontent.com/80658269/175962042-1f103e97-da17-456e-8283-6f4cb7185ecf.png)

defaultImageUrl은 props로 전달받습니다. 
예를 들어, 아래와 같이 사용가능합니다. 

![image](https://user-images.githubusercontent.com/80658269/175962570-7251f516-5507-4d7d-8272-5e827e9e0b27.png)

Avatar, PostBody, PostImageContainer에 각각 적용했습니다. 

## 구현 결과
엑박 이미지를 아래와 같은 디폴트 이미지로 대체해 보여줍니다. 

![image](https://user-images.githubusercontent.com/80658269/175962911-2d779c25-4167-44ab-b432-11da11c08763.png)

