### PR TITLE
refactor: userPosts state 삭제, 프로필 변경 이미지 추가

### DIFF
--- a/src/components/ChangeProfileModal/index.jsx
+++ b/src/components/ChangeProfileModal/index.jsx
@@ -2,7 +2,7 @@ import { Button, Text, UploadImage } from 'components';
 import styled from '@emotion/styled';
 import useClickAway from '../../hooks/useClickAway';
 
-const ChangeProfileModal = ({ onFileChange, onProfileSubmit, onClose }) => {
+const ChangeProfileModal = ({ onFileChange, onProfileSubmit, onClose, currentProfile }) => {
   const ref = useClickAway(() => {
     onClose && onClose();
   });
@@ -13,6 +13,7 @@ const ChangeProfileModal = ({ onFileChange, onProfileSubmit, onClose }) => {
           프로필을 변경하시겠습니까?
         </Text>
         <UploadImage
+          defaultImage={currentProfile}
           onChange={onFileChange}
           style={{ width: '90%', marginLeft: 'auto', marginRight: 'auto', marginTop: '30px' }}
         />{' '}

--- a/src/pages/MyInfoPage/UserProfile.jsx
+++ b/src/pages/MyInfoPage/UserProfile.jsx
@@ -101,6 +101,7 @@ const UserProfile = () => {
           onFileChange={onFileChange}
           onProfileSubmit={onProfileSubmit}
           onClose={onCloseProfile}
+          currentProfile={currentUser.image}
         />
       )}
     </UserProfileWrapper>

--- a/src/pages/UserPage/index.jsx
+++ b/src/pages/UserPage/index.jsx
@@ -24,7 +24,6 @@ const UserPage = () => {
   const { currentUser } = useUserContext();
   const [user, setUser] = useState(initialUserData.currentUser);
   const [userLevel, setUserLevel] = useState({});
-  const [userPosts, setUserPosts] = useState([]);
   const [userLikePosts, setUserLikePosts] = useState([]);
 
   const [currentTab, setCurrentTab] = useState(USER_POSTS);
@@ -39,7 +38,6 @@ const UserPage = () => {
       setUser(data);
       const { posts, comments, followers } = data;
       const { level } = getUserLevel({ posts, comments, followers });
-      setUserPosts(posts);
       setUserLevel(level);
     }
   }, [pageUserId]);
@@ -76,7 +74,7 @@ const UserPage = () => {
             }}
             index={USER_POSTS}
           >
-            <PostImageContainer posts={userPosts} />
+            <PostImageContainer posts={user.posts} />
           </Tab.Item>
           <Tab.Item
             icon={{


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용 
- [x]  post 대신 user.post를 사용
- [x]  프로필 사진 변경 모달에 현재 프로필사진 default로 보여주기
- [ ]  모달 정리 : 일단 상수화하고 추후 교체 예정

## 구현 결과

![프로필 기본이미지](https://user-images.githubusercontent.com/79133602/177297789-b87675e5-7a0a-402c-80f1-728f9d5d08b7.gif)

