### PR TITLE
fix: 팔로우 버튼 갱신 디버깅 및 최적화

### DIFF
--- a/src/components/FollowList/MyFollowList.jsx
+++ b/src/components/FollowList/MyFollowList.jsx
@@ -13,35 +13,35 @@ const FOLLOWER = 'follower';
 //TODO: follows 데이터 구조
 // const followData = [{ followId: '', userData: {}, followData: {}}]; // 팔로잉 기준 전부 isFollow true
 
-const FollowList = ({ followList, tab, handleFollowSuccess }) => {
+const FollowList = ({ followList, tab, handleFollowChange }) => {
   const { currentUser, onFollow, onUnfollow } = useUserContext();
   const [isModal, setIsModal] = useState(false);
   const [unfollowId, setUnfollowId] = useState('');
-  const [isFollowSuccess, setIsFollowSuccess] = useState(false);
+  const [isFollowChange, setIsFollowChange] = useState(false);
 
   const onClose = () => {
     setIsModal(false);
   };
 
-  const hadleFollow = useCallback(
+  const handleFollow = useCallback(
     (followId, userId) => {
       if (!currentUser.following.some((follow) => follow.user === userId)) {
         onFollow({ userId, followId });
-        setIsFollowSuccess(true);
+        setIsFollowChange(true);
+        handleFollowChange(true);
       } else {
-        setIsFollowSuccess(false);
+        setIsFollowChange(false);
       }
       setIsModal(true);
-      handleFollowSuccess(isFollowSuccess);
     },
-    [currentUser, onFollow, handleFollowSuccess, isFollowSuccess],
+    [currentUser, onFollow, handleFollowChange],
   );
 
-  const hadleUnFollow = useCallback(() => {
+  const handleUnFollow = useCallback(() => {
     onUnfollow({ unfollowId });
     setIsModal(false);
-    handleFollowSuccess(true);
-  }, [unfollowId, onUnfollow, handleFollowSuccess]);
+    handleFollowChange(true);
+  }, [unfollowId, onUnfollow, handleFollowChange]);
 
   return (
     //TODO: user._id:
@@ -84,7 +84,7 @@ const FollowList = ({ followList, tab, handleFollowSuccess }) => {
                   fontSize="16px"
                   style={{ ...followButtonStyle }}
                   onClick={() => {
-                    hadleFollow(followId, followData.follower);
+                    handleFollow(followId, followData.follower);
                   }}
                 >
                   팔로우
@@ -93,7 +93,7 @@ const FollowList = ({ followList, tab, handleFollowSuccess }) => {
             </ProfileContainer>
           );
         })}{' '}
-      {tab === FOLLOWER && !isFollowSuccess && isModal && (
+      {tab === FOLLOWER && !isFollowChange && isModal && (
         <Modal visible={isModal} onClose={onClose}>
           <Modal.Content
             title="팔로우 실패했어요!"
@@ -103,7 +103,7 @@ const FollowList = ({ followList, tab, handleFollowSuccess }) => {
           <Modal.Button onClick={onClose}>확인</Modal.Button>
         </Modal>
       )}
-      {tab === FOLLOWER && isFollowSuccess && isModal && (
+      {tab === FOLLOWER && isFollowChange && isModal && (
         <Modal visible={isModal} onClose={onClose}>
           <Modal.Content title="팔로우에 성공했어요!" onClose={onClose} />
           <Modal.Button onClick={onClose}>확인</Modal.Button>
@@ -118,7 +118,7 @@ const FollowList = ({ followList, tab, handleFollowSuccess }) => {
           />
           <Modal.Button
             onClick={() => {
-              hadleUnFollow();
+              handleUnFollow();
             }}
           >
             확인

--- a/src/components/PostImageContainer/index.jsx
+++ b/src/components/PostImageContainer/index.jsx
@@ -10,25 +10,32 @@ const PostImageContainer = ({ posts }) => {
 
   return (
     <PostImageList>
-      {posts.map((post) => (
-        <ImageItem
-          key={post._id}
-          onClick={() => {
-            navigate(`/post/detail/${post._id}`);
-          }}
-        >
-          <Image
-            src={post.image ? post.image : IMAGE_URLS.POST_DEFAULT_IMG}
-            height="100%"
-            width="100%"
-            mode="cover"
-            lazy={true}
-            threshold={0.4}
-            placeholder={IMAGE_URLS.POST_DEFAULT_IMG}
-            style={{ position: 'absolute', left: 0, top: 0 }}
-          />
-        </ImageItem>
-      ))}
+      {posts.map((post) => {
+        const data =
+          Object.hasOwnProperty.call(post, 'status') && post.status === 'fulfilled'
+            ? post.value
+            : post;
+        return (
+          <ImageItem
+            key={data._id}
+            onClick={() => {
+              navigate(`/post/detail/${data._id}`);
+            }}
+          >
+            <Image
+              src={data.image ? data.image : IMAGE_URLS.POST_DEFAULT_IMG}
+              height="100%"
+              width="100%"
+              mode="cover"
+              lazy={true}
+              threshold={0.4}
+              placeholder={IMAGE_URLS.POST_DEFAULT_IMG}
+              style={{ position: 'absolute', left: 0, top: 0 }}
+              defaultImageUrl={IMAGE_URLS.POST_DEFAULT_GRID_IMG}
+            />
+          </ImageItem>
+        );
+      })}
     </PostImageList>
   );
 };

--- a/src/components/PostImageContainer/index.jsx
+++ b/src/components/PostImageContainer/index.jsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import { Image } from 'components';
 import { IMAGE_URLS } from 'utils/constants/images';
 
-const PostImageContainer = React.memo(function ImageContainer({ posts }) {
+const PostImageContainer = ({ posts }) => {
   const navigate = useNavigate();
 
   return (
@@ -31,9 +31,9 @@ const PostImageContainer = React.memo(function ImageContainer({ posts }) {
       ))}
     </PostImageList>
   );
-});
+};
 
-export default PostImageContainer;
+export default React.memo(PostImageContainer);
 
 PostImageContainer.prototype = {
   posts: PropTypes.array,

--- a/src/pages/FollowPage/index.jsx
+++ b/src/pages/FollowPage/index.jsx
@@ -16,20 +16,10 @@ const FollowPage = () => {
   const [followingData, setFollowingData] = useState([]); // 얘는 해당 user(id) 유저 정보들의 배열 vs following은 id가 담긴 배열
   const [followerData, setFollowerData] = useState([]); // 얘는 해당 follower(id) 유저 정보들의 배열 vs followers는 id가 담긴 배열
   const { currentUser } = useUserContext();
-  const [isFollowSuccess, setIsFollowSuccess] = useState(false);
+  const [isFollowChange, setIsFollowChange] = useState(false);
 
-  useEffect(() => {
-    if (currentUser.id !== id) {
-      handleGetUser();
-      setIsMyFollow(false);
-    } else {
-      setUser(currentUser);
-      setIsMyFollow(true);
-    }
-  }, [currentUser]);
-
-  const handleFollowSuccess = (value) => {
-    setIsFollowSuccess(value);
+  const handleFollowChange = (value) => {
+    setIsFollowChange(value);
   };
 
   //TODO:신영 현재 페이지 유저의 정보 => 전역데이터가 아닌 경우 context를 사용할 수 없어서 직접 api 호출
@@ -44,6 +34,16 @@ const FollowPage = () => {
   const onActive = (value) => {
     setCurrentTab(value);
   };
+
+  useEffect(() => {
+    if (currentUser.id !== id) {
+      handleGetUser();
+      setIsMyFollow(false);
+    } else {
+      setUser(currentUser);
+      setIsMyFollow(true);
+    }
+  }, [currentUser, id, handleGetUser]);
 
   //FOLLOWING: 내가 팔로잉 한 사람들 user: 그놈들 id , follower: 내 id
   const handleGetFollowing = useCallback(async () => {
@@ -63,6 +63,7 @@ const FollowPage = () => {
     } else {
       setFollowingData([]);
     }
+    setIsFollowChange(false);
   }, [user]);
 
   //FOLLOWERS: 나를 팔로잉 한 사람들 user: 내 id , follower: 그 놈들 id
@@ -81,17 +82,24 @@ const FollowPage = () => {
       );
       setFollowerData(data);
     }
+    setIsFollowChange(false);
   }, [user]);
-
+  
   useEffect(() => {
-    if (currentTab === FOLLOWING && (followingData.length === 0 || isFollowSuccess)) {
+    if (currentTab === FOLLOWING && (followingData.length === 0 || isFollowChange)) {
       handleGetFollowing();
-      setIsFollowSuccess(false);
     } else if (currentTab === FOLLOWER && followerData.length === 0) {
       handleGetFollowers();
-      setIsFollowSuccess(false);
     }
-  }, [user, currentTab]);
+  }, [
+    currentTab,
+    user,
+    isFollowChange,
+    followingData,
+    followerData,
+    handleGetFollowing,
+    handleGetFollowers,
+  ]);
 
   return (
     <PageWrapper header nav prev title={user.fullName}>
@@ -101,7 +109,7 @@ const FollowPage = () => {
             <MyFollowList
               followList={followerData}
               tab={FOLLOWER}
-              handleFollowSuccess={handleFollowSuccess}
+              handleFollowChange={handleFollowChange}
             />
           ) : (
             <FollowList followList={followerData} />
@@ -112,7 +120,7 @@ const FollowPage = () => {
             <MyFollowList
               followList={followingData}
               tab={FOLLOWING}
-              handleFollowSuccess={handleFollowSuccess}
+              handleFollowChange={handleFollowChange}
             />
           ) : (
             <FollowList followList={followingData} />

--- a/src/pages/UserPage/PostData.jsx
+++ b/src/pages/UserPage/PostData.jsx
@@ -1,0 +1,68 @@
+import {
+  GRID_INACTIVE,
+  GRID_ACTIVE,
+  HEART_INACTIVE,
+  HEART_ACTIVE,
+} from 'utils/constants/icons/names';
+import { Icon, PostImageContainer, Tab } from 'components';
+import React, { useEffect, useState, useCallback } from 'react';
+import { getPostData } from 'utils/apis/postApi';
+
+const USER_POSTS = 'userPosts';
+const LIKE_POSTS = 'likePosts';
+
+const PostData = ({ user }) => {
+  const [userLikePosts, setUserLikePosts] = useState([]);
+  const [currentTab, setCurrentTab] = useState(USER_POSTS);
+
+  const onActive = (value) => {
+    setCurrentTab(value);
+  };
+
+  const handleGetLikePosts = useCallback(async () => {
+    const { likes } = user;
+    if (likes.length !== 0) {
+      const data = await Promise.all(
+        likes.map((like) => getPostData(like.post).then((result) => result.data)),
+      );
+      setUserLikePosts(data);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (currentTab === LIKE_POSTS && user.likes.length !== 0) {
+      handleGetLikePosts();
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (currentTab === LIKE_POSTS && userLikePosts.length === 0) {
+      handleGetLikePosts();
+    }
+  }, [currentTab, handleGetLikePosts, userLikePosts]);
+
+  return (
+    <Tab onActive={onActive}>
+      <Tab.Item
+        icon={{
+          active: <Icon name={GRID_ACTIVE} size={24} />,
+          inactive: <Icon name={GRID_INACTIVE} size={24} />,
+        }}
+        index={USER_POSTS}
+      >
+        <PostImageContainer posts={user.posts} />
+      </Tab.Item>
+      <Tab.Item
+        icon={{
+          active: <Icon name={HEART_ACTIVE} size={24} />,
+          inactive: <Icon name={HEART_INACTIVE} size={24} />,
+        }}
+        index={LIKE_POSTS}
+      >
+        <PostImageContainer posts={userLikePosts} />
+      </Tab.Item>
+    </Tab>
+  );
+};
+
+export default React.memo(PostData);

--- a/src/pages/UserPage/PostData.jsx
+++ b/src/pages/UserPage/PostData.jsx
@@ -22,10 +22,14 @@ const PostData = ({ user }) => {
   const handleGetLikePosts = useCallback(async () => {
     const { likes } = user;
     if (likes.length !== 0) {
-      const data = await Promise.all(
-        likes.map((like) => getPostData(like.post).then((result) => result.data)),
-      );
-      setUserLikePosts(data);
+      try {
+        const data = await Promise.allSettled(
+          likes.map((like) => getPostData(like.post).then((result) => result.data)),
+        );
+        setUserLikePosts(data);
+      } catch (error) {
+        console.error(error);
+      }
     }
   }, [user]);
 

--- a/src/pages/UserPage/UserData.jsx
+++ b/src/pages/UserPage/UserData.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { Text, Avatar, Button, Image, Modal } from 'components';
 import { useUserContext } from 'contexts/UserContext';
 import theme from 'styles/theme';
@@ -18,11 +18,19 @@ import {
 
 const UserData = ({ user, pageUserId, userLevel }) => {
   const { currentUser, onFollow, onUnfollow } = useUserContext();
-  const checkFollow = currentUser.following.some((follow) => follow.user === pageUserId);
-  const [isFollow, setIsFollow] = useState(checkFollow);
+  const followData = currentUser.following.filter((follow) => follow.user === pageUserId);
+  const [isFollow, setIsFollow] = useState(false);
   const [isFollowModal, setIsFollowModal] = useState(false);
   const [isUnFollowModal, setIsUnFollowModal] = useState(false);
   const [followers, setFollowers] = useState();
+
+  useEffect(() => {
+    setIsFollow(followData.length === 0 ? false : true);
+  }, [followData]);
+
+  useEffect(() => {
+    setFollowers(user.followers.length);
+  }, [user]);
 
   const navigate = useNavigate();
 
@@ -34,7 +42,7 @@ const UserData = ({ user, pageUserId, userLevel }) => {
     setIsUnFollowModal(false);
   };
 
-  const hadleFollow = useCallback(() => {
+  const handleFollow = useCallback(() => {
     if (!isFollow) {
       onFollow({ userId: pageUserId, followId: '' });
       setIsFollowModal(true);
@@ -44,9 +52,7 @@ const UserData = ({ user, pageUserId, userLevel }) => {
     setIsFollow(true);
   }, [pageUserId, isFollow, onFollow, followers]);
 
-  const hadleUnFollow = useCallback(() => {
-    const followData = currentUser.following.filter((follow) => follow.user === pageUserId);
-
+  const handleUnFollow = useCallback(() => {
     if (followData.length !== 0) {
       onUnfollow({ unfollowId: followData[0]._id });
       setIsFollow(false);
@@ -55,11 +61,7 @@ const UserData = ({ user, pageUserId, userLevel }) => {
       }
     }
     setIsUnFollowModal(false);
-  }, [pageUserId, currentUser, onUnfollow, followers]);
-
-  useEffect(() => {
-    setFollowers(user.followers.length);
-  }, [user]);
+  }, [followData, onUnfollow, followers]);
 
   return (
     <UserInfo>
@@ -127,7 +129,7 @@ const UserData = ({ user, pageUserId, userLevel }) => {
           borderRadius={10}
           fontSize="16px"
           style={{ ...followButtonStyle }}
-          onClick={hadleFollow}
+          onClick={handleFollow}
         >
           팔로우
         </Button>
@@ -150,7 +152,7 @@ const UserData = ({ user, pageUserId, userLevel }) => {
         />
         <Modal.Button
           onClick={() => {
-            hadleUnFollow();
+            handleUnFollow();
           }}
         >
           확인
@@ -167,7 +169,7 @@ const UserData = ({ user, pageUserId, userLevel }) => {
   );
 };
 
-export default UserData;
+export default React.memo(UserData);
 
 UserData.propTypes = {
   user: PropTypes.object,

--- a/src/pages/UserPage/index.jsx
+++ b/src/pages/UserPage/index.jsx
@@ -1,92 +1,41 @@
 import { useEffect, useState, useCallback } from 'react';
-import { Icon, PostImageContainer, PageWrapper, Tab } from 'components';
+import { PageWrapper } from 'components';
 import { useParams } from 'react-router-dom';
-import { initialUserData } from 'contexts/UserContext/reducer';
 import { useUserContext } from 'contexts/UserContext';
 import { getUser } from 'utils/apis/userApi';
-import { getPostData } from 'utils/apis/postApi';
-import {
-  GRID_INACTIVE,
-  GRID_ACTIVE,
-  HEART_INACTIVE,
-  HEART_ACTIVE,
-} from 'utils/constants/icons/names';
 import { UserContainer } from './style';
 import UserData from './UserData';
+import PostData from './PostData';
 import getUserLevel from 'utils/functions/userLevel/getUserLevel';
-
-const USER_POSTS = 'userPosts';
-const LIKE_POSTS = 'likePosts';
 
 const UserPage = () => {
   const { id } = useParams();
-  const pageUserId = id;
   const { currentUser } = useUserContext();
-  const [user, setUser] = useState(initialUserData.currentUser);
+  const [user, setUser] = useState({});
   const [userLevel, setUserLevel] = useState({});
-  const [userLikePosts, setUserLikePosts] = useState([]);
-
-  const [currentTab, setCurrentTab] = useState(USER_POSTS);
-
-  const onActive = (value) => {
-    setCurrentTab(value);
-  };
 
   const handleGetUser = useCallback(async () => {
-    if (pageUserId) {
-      const { data } = await getUser(pageUserId);
+    if (id) {
+      const { data } = await getUser(id);
       setUser(data);
       const { posts, comments, followers } = data;
       const { level } = getUserLevel({ posts, comments, followers });
       setUserLevel(level);
     }
-  }, [pageUserId]);
-
-  const handleGetLikePosts = useCallback(async () => {
-    const { likes } = user;
-    if (likes.length !== 0) {
-      const data = await Promise.all(
-        likes.map((like) => getPostData(like.post).then((result) => result.data)),
-      );
-      setUserLikePosts(data);
-    }
-  }, [user]);
+  }, [id]);
 
   useEffect(() => {
     handleGetUser();
-  }, [pageUserId, handleGetUser]);
-
-  useEffect(() => {
-    if (currentTab === LIKE_POSTS && userLikePosts.length === 0) {
-      handleGetLikePosts();
-    }
-  }, [currentTab, handleGetLikePosts, userLikePosts]);
+  }, [id, handleGetUser]);
 
   return (
-    <PageWrapper header prev nav info={currentUser.id === pageUserId}>
-      <UserContainer>
-        <UserData user={user} pageUserId={pageUserId} userLevel={userLevel} />
-        <Tab onActive={onActive}>
-          <Tab.Item
-            icon={{
-              active: <Icon name={GRID_ACTIVE} size={24} />,
-              inactive: <Icon name={GRID_INACTIVE} size={24} />,
-            }}
-            index={USER_POSTS}
-          >
-            <PostImageContainer posts={user.posts} />
-          </Tab.Item>
-          <Tab.Item
-            icon={{
-              active: <Icon name={HEART_ACTIVE} size={24} />,
-              inactive: <Icon name={HEART_INACTIVE} size={24} />,
-            }}
-            index={LIKE_POSTS}
-          >
-            <PostImageContainer posts={userLikePosts} />
-          </Tab.Item>
-        </Tab>
-      </UserContainer>
+    <PageWrapper header prev nav info={currentUser.id === id}>
+      {Object.keys(user).length !== 0 && (
+        <UserContainer>
+          <UserData user={user} pageUserId={id} userLevel={userLevel} />
+          <PostData user={user} />
+        </UserContainer>
+      )}
     </PageWrapper>
   );
 };


### PR DESCRIPTION
## 📌 기능 설명 

- [x]  팔로우 버튼 마이페이지에서 뒤로가기 또는 새로고침시 버튼이 안먹혀 중복 팔로우가 된다.
- [x]  팔로우 삭제 후 팔로잉했을 때 버그 → 팔로잉에 바로 추가가 안됨
- [x]  사용자 페이지 코드 정리 및 최적화
- [x]  사용자 페이지 좋아요 API 호출시 Promise.all => Promise.allSettled로 변경

## 👩‍💻 요구 사항과 구현 내용 

###  1. 사용자 페이지 디버깅

> 원인 : setState는 비동기적 처리

checkFollow의 연산이 완료가 되기 전에 setIsFollow가 끝났기 때문에 setIsFollow(undefined)가 들어가서 follow가 안된 사용자처럼 보였던 거다. 

> 해결방법

checkFollow의 값이 변경될 때마다 setIsFollow를 해주도록 했다.

![image](https://user-images.githubusercontent.com/79133602/178433994-1daf7d32-3135-473d-8b8d-121d0bb00581.png)

### 2. 팔로우 삭제후 다시 팔로우하면 팔로잉에 들어가게 디버깅


> 원인: following 데이터가 바뀌지 않았다!

현재 팔로잉 목록을 가져올 때 contextApi로 만든 userContext의 currentUser 정보중 following 배열을 사용한다. 그런데 handleGetFollowing의 결과 data를 보면 following 배열이 팔로우 이후 변화가 없다. 그래서 팔로잉 리스트가 갱신이 되지 않았다.

> 해결: user를 의존 배열에 추가

이러면 user의 변경 사항이 반영된다. 이때 setIsFollowChange handle 함수들 안에 넣어서 handle이 완료되기도 전에 useEffect가 다시 실행되는 버그를 막았다. 

![image](https://user-images.githubusercontent.com/79133602/178434220-7f7f5749-1a50-49e7-a054-68cdcb6ed6f9.png)


### 3. 페이지 최적화

팔로우, 언팔을 하더라도 사용자가 좋아요한 포스트와 작성한 포스트가 바뀌지 않기에 불필요한 렌더링이 있었다. 그래서 좋아요한 포스트, 작성한 포스트를 보여주는 컴포넌트를 분리 후 React.memo로 props가 변경됐을 때만 리렌더링하도록했다.

### 4. Promise.allSettled 사용 

Promise.all을 사용하면 요청 하나만 에러나도 나머지 멀쩡한 요청들 모두 catch문으로 들어가 버리는 문제가 있었다. 그래서 요청이 실패해도 다음 요청을 전부 실행하는 Promise.allSettled로 바꿨다. 

![image](https://user-images.githubusercontent.com/79133602/178564744-76c07d07-7bbf-45e5-aea5-500040e48e3a.png)

그런데 Promise.allSettled의 경우 데이터 객체를 바로 반환하지 않고 `{status: '성공여부', value: {데이터} }` 이런식으로 반환하기에  PostImageContainer에 아래 코드를 추가해서 status 속성이 있고 status가 fulfilled일 땐 post.value를 아니라면 데이터객체가 있는 배열이기에 post를 데이터에 할당하도록 했다. 

![image](https://user-images.githubusercontent.com/79133602/178564661-d39225ab-370a-4e9d-819a-6826d58e0766.png)


## 구현 결과

https://user-images.githubusercontent.com/79133602/178433575-03593726-e2d5-4236-8315-0d2d969dea59.mp4


