### PR TITLE
fix: 리렌더링할 때마다 스크롤이 위로 이동하는 버그 수정

### DIFF
--- a/src/hooks/useScrollToTop.js
+++ b/src/hooks/useScrollToTop.js
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const useScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default useScrollToTop;

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import useLocalToken from 'hooks/useLocalToken';
 import { Routes, Route } from 'react-router-dom';
 import { useUserContext } from 'contexts/UserContext';
-import scrollToTop from 'utils/functions/scrollToTop';
+import useScrollToTop from 'hooks/useScrollToTop';
 import PrivateWrapper from './PrivateWrapper';
 import {
   LoginPage,
@@ -23,7 +23,7 @@ import {
 const Router = () => {
   const [token] = useLocalToken();
   const { onKeepLoggedIn } = useUserContext();
-  scrollToTop();
+  useScrollToTop();
 
   useEffect(() => {
     token && onKeepLoggedIn();

--- a/src/utils/functions/scrollToTop.js
+++ b/src/utils/functions/scrollToTop.js
@@ -1,3 +1,0 @@
-export default function scrollToTop() {
-  window.scrollTo(0, 0);
-}


### PR DESCRIPTION
## ✅ 이슈 번호
#204 

## 📌 기능 설명 
리렌더링할 때마다 스크롤이 위로 이동하는 버그가 있었습니다. 
예를 들어, 댓글 작성 후 완료 버튼을 누르면 스크롤이 위로 이동합니다. 
이 버그를 수정했습니다. 

아래의 유틸 함수를 
![image](https://user-images.githubusercontent.com/80658269/179818090-aa93091d-e31d-4f80-9067-e4c0bd5d48f5.png)


커스텀 훅으로 변경했습니다. 
![image](https://user-images.githubusercontent.com/80658269/179819003-dc619d4a-2d48-4764-95f4-f80e236de64a.png)

pathname의 상태를 기억하고, 
pathname이 변경되지 않으면 스크롤이 발생하지 않도록 처리했습니다. 

https://user-images.githubusercontent.com/80658269/179818816-44e185ea-0a1a-4be0-9698-38b39629f121.mp4

리렌더링 시에 스크롤이 위로 이동하지 않습니다. 
