### PR TITLE
refactor: 사용자 페이지 최적화 & 팔로우 버튼 숨기기

### DIFF
--- a/src/components/PostImageContainer/index.jsx
+++ b/src/components/PostImageContainer/index.jsx
@@ -1,42 +1,56 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { Image } from 'components';
 import { IMAGE_URLS } from 'utils/constants/images';
 
-const PostImageContainer = ({ posts }) => {
+const PostImageContainer = ({ posts, handleObserver = null }) => {
   const navigate = useNavigate();
+  const interSectRef = useRef(null);
+
+  useEffect(() => {
+    if (handleObserver) {
+      const observer = new IntersectionObserver(handleObserver, { threshold: 0.1 });
+      if (interSectRef.current) {
+        observer.observe(interSectRef.current);
+      }
+      return () => observer.disconnect();
+    }
+  }, [handleObserver]);
 
   return (
-    <PostImageList>
-      {posts.map((post) => {
-        const data =
-          Object.hasOwnProperty.call(post, 'status') && post.status === 'fulfilled'
-            ? post.value
-            : post;
-        return (
-          <ImageItem
-            key={data._id}
-            onClick={() => {
-              navigate(`/post/detail/${data._id}`);
-            }}
-          >
-            <Image
-              src={data.image ? data.image : IMAGE_URLS.POST_DEFAULT_IMG}
-              height="100%"
-              width="100%"
-              mode="cover"
-              lazy={true}
-              threshold={0.4}
-              placeholder={IMAGE_URLS.POST_DEFAULT_IMG}
-              style={{ position: 'absolute', left: 0, top: 0 }}
-              defaultImageUrl={IMAGE_URLS.POST_DEFAULT_GRID_IMG}
-            />
-          </ImageItem>
-        );
-      })}
-    </PostImageList>
+    <>
+      <PostImageList>
+        {posts.map((post) => {
+          const data =
+            Object.hasOwnProperty.call(post, 'status') && post.status === 'fulfilled'
+              ? post.value
+              : post;
+          return (
+            <ImageItem
+              key={data._id}
+              onClick={() => {
+                navigate(`/post/detail/${data._id}`);
+              }}
+            >
+              <Image
+                src={data.image ? data.image : IMAGE_URLS.POST_DEFAULT_IMG}
+                height="100%"
+                width="100%"
+                mode="cover"
+                lazy={true}
+                threshold={0.4}
+                placeholder={IMAGE_URLS.POST_DEFAULT_IMG}
+                style={{ position: 'absolute', left: 0, top: 0 }}
+                defaultImageUrl={IMAGE_URLS.POST_DEFAULT_GRID_IMG}
+              />
+            </ImageItem>
+          );
+        })}
+      </PostImageList>
+      <div ref={interSectRef} />
+    </>
   );
 };
 

--- a/src/pages/UserPage/UserData.jsx
+++ b/src/pages/UserPage/UserData.jsx
@@ -5,6 +5,7 @@ import theme from 'styles/theme';
 import { IMAGE_URLS } from 'utils/constants/images';
 import { useNavigate } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import useLocalToken from 'hooks/useLocalToken';
 
 import {
   followButtonStyle,
@@ -17,12 +18,15 @@ import {
 } from './style';
 
 const UserData = ({ user, pageUserId, userLevel }) => {
+  const [token] = useLocalToken();
   const { currentUser, onFollow, onUnfollow } = useUserContext();
   const followData = currentUser.following.filter((follow) => follow.user === pageUserId);
   const [isFollow, setIsFollow] = useState(false);
   const [isFollowModal, setIsFollowModal] = useState(false);
   const [isUnFollowModal, setIsUnFollowModal] = useState(false);
   const [followers, setFollowers] = useState();
+  const isFollowButton = token && currentUser.id !== pageUserId && isFollow;
+  const isUnfollowButton = token && currentUser.id !== pageUserId && !isFollow;
 
   useEffect(() => {
     setIsFollow(followData.length === 0 ? false : true);
@@ -106,7 +110,7 @@ const UserData = ({ user, pageUserId, userLevel }) => {
         </UserDetail>
       </UserDetailWrapper>
 
-      {currentUser.id !== pageUserId && isFollow && (
+      {isFollowButton && (
         <Button
           width={100}
           height={30}
@@ -122,7 +126,7 @@ const UserData = ({ user, pageUserId, userLevel }) => {
           팔로잉
         </Button>
       )}
-      {currentUser.id !== pageUserId && !isFollow && (
+      {isUnfollowButton && (
         <Button
           width={100}
           height={30}


### PR DESCRIPTION
## 📌 기능 설명 

- [x] 좋아요 포스트 무한스크롤 적용
- [x] 로그인한 유저만 팔로우 버튼 보기


## 👩‍💻 요구 사항과 구현 내용 

### 1. 좋아요 포스트 목록에  무한스크롤 적용
> 현재 Promise.allSettled로 호출이 많아서 렌더링도 느리고 서버에도 부담됨

- 렌더링 4초 걸림... 

https://user-images.githubusercontent.com/79133602/179847230-eb19d2eb-07bf-43eb-a44a-5f85f17be05e.mp4

- 9개 먼저 받고 이후에 6개씩 끊어서 받도록 해결

![image](https://user-images.githubusercontent.com/79133602/179847481-11ab7ccd-a65e-41e5-94bd-317876725c11.png)

- PostImageContainer에 intersetionObsever 구축

![image](https://user-images.githubusercontent.com/79133602/179847693-57ca2466-30ce-4ab6-9366-f1b441dc0865.png)


소진님 부분엔 적용 안되도록 handleObserver 기본 값을 null로 주고 null이 아닐 떄만 IntersectionObserver가 작동

### 2. 팔로우 버튼 숨기기

로그인한 유저만 볼 수 있도록 조건문 추가

![image](https://user-images.githubusercontent.com/79133602/179848091-c23aaacf-06e4-4072-8d7e-73d7a153612a.png)


## 구현 결과

https://user-images.githubusercontent.com/79133602/179848120-ca159eeb-e44a-449c-b9d0-1ad408c24c2c.mp4

- 전 
![image](https://user-images.githubusercontent.com/79133602/179848485-c595de17-61d1-461d-88eb-30967fb143e3.png)

- 후
![image](https://user-images.githubusercontent.com/79133602/179848427-e695e1b7-ae62-4c4b-b65f-c5779b489088.png)
