### PR TITLE
refactor: SWR을 적용하여 성능 보완

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^18.1.0",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
+    "swr": "^1.3.0",
     "web-vitals": "^2.1.4",
     "yarn": "^1.22.19"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,18 @@
 import ContextProviders from 'contexts';
 import DefaultTemplate from 'template/DefaultTemplate';
 import Router from 'routes/Router';
+import { SWRConfig } from 'swr';
+import { swrOptions } from 'utils/apis/swrOptions';
 
 const App = () => {
   return (
-    <ContextProviders>
-      <DefaultTemplate>
-        <Router />
-      </DefaultTemplate>
-    </ContextProviders>
+    <SWRConfig value={swrOptions}>
+      <ContextProviders>
+        <DefaultTemplate>
+          <Router />
+        </DefaultTemplate>
+      </ContextProviders>
+    </SWRConfig>
   );
 };
 

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -48,17 +48,6 @@ export const Header = ({ prev, title, info, complete, onComplete }) => {
     navigate(-1);
   };
 
-  const [token] = useLocalToken();
-  useEffect(() => {
-    const initNotifications = async () => {
-      const fetchedNotifications = await getNotifications(token);
-      setIsSeen(
-        fetchedNotifications.data.length === 0 ? isSeen : fetchedNotifications.data[0].seen,
-      );
-    };
-    initNotifications();
-  }, [token, isSeen]);
-
   return (
     <HeaderContainer top height={headerHeight}>
       <div>{prev && <Icon.Button name="ARROW_LEFT" size={20} onClick={onClickPrev} />}</div>
@@ -68,11 +57,11 @@ export const Header = ({ prev, title, info, complete, onComplete }) => {
       <InnerRight>
         {info && (
           <>
-            {token && (
+            {
               <Badge dot={isSeen}>
                 <Icon.Link to="/user/notification" name="NOTIFICATION" size={30} />
               </Badge>
-            )}
+            }
             <Icon.Link to="/user/myinfo" name="MY_INFO" size={30} />
           </>
         )}

--- a/src/components/basic/Spinner/index.jsx
+++ b/src/components/basic/Spinner/index.jsx
@@ -1,0 +1,47 @@
+import styled from '@emotion/styled';
+
+const Spinner = ({ size = 32, color = '#30A57D', loading = true, ...props }) => {
+  const sizeStyle = {
+    width: size,
+    height: size,
+  };
+
+  return loading ? (
+    <Icon>
+      <svg viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg" style={sizeStyle}>
+        <g fill="none" fillRule="evenodd">
+          <g transform="translate(1 1)">
+            <path d="M36 18c0-9.94-8.06-18-18-18" stroke={color} strokeWidth="2">
+              <animateTransform
+                attributeName="transform"
+                type="rotate"
+                from="0 18 18"
+                to="360 18 18"
+                dur="0.9s"
+                repeatCount="indefinite"
+              />
+            </path>
+            <circle fill={color} cx="36" cy="18" r="1">
+              <animateTransform
+                attributeName="transform"
+                type="rotate"
+                from="0 18 18"
+                to="360 18 18"
+                dur="0.9s"
+                repeatCount="indefinite"
+              />
+            </circle>
+          </g>
+        </g>
+      </svg>
+    </Icon>
+  ) : null;
+};
+
+const Icon = styled.i`
+  display: block;
+  text-align: center;
+  vertical-align: middle;
+`;
+
+export default Spinner;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -6,6 +6,7 @@ export { default as Input } from './basic/Input';
 export { default as PageWrapper } from './basic/PageWrapper';
 export { default as Tab } from './basic/Tab';
 export { default as Text } from './basic/Text';
+export { default as Spinner } from './basic/Spinner';
 
 export { default as ChangeNameForm } from './ChangeNameForm';
 export { default as ChangePasswordForm } from './ChangePasswordForm';

--- a/src/contexts/UserContext/handles.jsx
+++ b/src/contexts/UserContext/handles.jsx
@@ -42,13 +42,12 @@ const useHandles = () => {
 
   const handleLogin = useCallback(
     async (inputData) => {
-      // JWT 토큰 및 로컬 스토리지 초기화
       setLocalToken('');
       localStorage.clear();
       const res = await login(inputData);
       if (res.data.token) {
-        setLocalToken(res.data.token); // 로그인 성공 시, JWT 토큰 갱신
-        navigate('/', { replace: true }); // 메인페이지로 이동
+        setLocalToken(res.data.token); 
+        navigate('/', { replace: true }); 
       }
       return { user: res.data.user, token: res.data.token };
     },
@@ -57,13 +56,11 @@ const useHandles = () => {
 
   const handleSignup = useCallback(
     async (inputData) => {
-      // JWT 토큰 및 로컬 스토리지 초기화
       setLocalToken('');
       localStorage.clear();
       const { data, error } = await signup(inputData);
       if (data.token) {
-        setLocalToken(data.token); // 회원가입 성공 시, JWT 토큰 갱신
-        //navigate('/', { replace: true }); // 메인 페이지로 이동 (로그인을 건너뛴다)
+        setLocalToken(data.token); 
         await login(inputData);
       }
       return data;
@@ -75,13 +72,11 @@ const useHandles = () => {
     if (localToken) {
       await logout(localToken);
     }
-    // JWT 토큰 및 로컬 스토리지 초기화
     setLocalToken('');
     localStorage.clear();
-    navigate('/login', { replace: true }); // 로그인 페이지로 이동
+    navigate('/login', { replace: true }); 
   }, [navigate, localToken, setLocalToken]);
 
-  //회원 이름수정
   const handlechangeUserName = useCallback(
     async (fullName, username) => {
       if (localToken && fullName) {
@@ -91,7 +86,6 @@ const useHandles = () => {
     [localToken],
   );
 
-  //회원 프로필 사진 수정
   const handlechangeProfile = useCallback(
     async ({ image }) => {
       const byteString = atob(image.split(',')[1]);
@@ -117,7 +111,6 @@ const useHandles = () => {
     [localToken],
   );
 
-  //회원 비밀번호 수정
   const handlechangePassword = useCallback(
     async (password) => {
       if (localToken && password) {
@@ -127,7 +120,6 @@ const useHandles = () => {
     [localToken],
   );
 
-  //팔로우
   const handlefollow = useCallback(
     async (userId) => {
       if (localToken && userId) {
@@ -139,7 +131,6 @@ const useHandles = () => {
     [localToken],
   );
 
-  //언팔
   const handleUnFollow = useCallback(
     async (followId) => {
       if (localToken && followId) {
@@ -149,7 +140,6 @@ const useHandles = () => {
     [localToken],
   );
 
-  // 포스트 등록
   const handleAddPost = useCallback(
     async (title, image) => {
       const formData = await objectToForm({ title, image, channelId });

--- a/src/contexts/UserContext/index.jsx
+++ b/src/contexts/UserContext/index.jsx
@@ -21,13 +21,15 @@ import {
   ADD_COMMENT,
   DELETE_COMMENT,
 } from './types';
+import { postListKey } from 'hooks/useSWRPostList';
+import { mutate } from 'swr';
 
 export const UserContext = createContext(initialUserData);
 export const useUserContext = () => useContext(UserContext);
 
 const UserProvider = ({ children }) => {
-  const [{ currentUser, isLoading }, dispatch] = useReducer(reducer, initialUserData); 
-  const [localToken] = useLocalToken(); 
+  const [{ currentUser, isLoading }, dispatch] = useReducer(reducer, initialUserData);
+  const [localToken] = useLocalToken();
   const {
     handleGetCurrentUser,
     handleLogin,
@@ -50,7 +52,7 @@ const UserProvider = ({ children }) => {
       dispatch({ type: LOADING_ON });
       const { user, token } = await handleLogin(data);
       if (token) {
-        dispatch({ type: LOGIN, payload: user }); 
+        dispatch({ type: LOGIN, payload: user });
       }
       dispatch({ type: LOADING_OFF });
     },
@@ -63,7 +65,7 @@ const UserProvider = ({ children }) => {
       const res = await handleSignup(data);
 
       if (res.token) {
-        dispatch({ type: SIGNUP, payload: res.user }); 
+        dispatch({ type: SIGNUP, payload: res.user });
       }
       dispatch({ type: LOADING_OFF });
     },
@@ -73,7 +75,7 @@ const UserProvider = ({ children }) => {
   const onLogout = useCallback(async () => {
     dispatch({ type: LOADING_ON });
     handleLogout();
-    dispatch({ type: LOGOUT }); 
+    dispatch({ type: LOGOUT });
     dispatch({ type: LOADING_OFF });
   }, [handleLogout]);
 
@@ -134,6 +136,7 @@ const UserProvider = ({ children }) => {
     async (title, image) => {
       const post = await handleAddPost(title, image);
       dispatch({ type: ADD_POST, payload: post });
+      mutate(postListKey, undefined, true);
     },
     [handleAddPost],
   );

--- a/src/contexts/UserContext/index.jsx
+++ b/src/contexts/UserContext/index.jsx
@@ -26,8 +26,8 @@ export const UserContext = createContext(initialUserData);
 export const useUserContext = () => useContext(UserContext);
 
 const UserProvider = ({ children }) => {
-  const [{ currentUser, isLoading }, dispatch] = useReducer(reducer, initialUserData); // 데이터의 갱신은 reducer 함수로 관리한다.
-  const [localToken] = useLocalToken(); // JWT 토큰
+  const [{ currentUser, isLoading }, dispatch] = useReducer(reducer, initialUserData); 
+  const [localToken] = useLocalToken(); 
   const {
     handleGetCurrentUser,
     handleLogin,
@@ -50,7 +50,7 @@ const UserProvider = ({ children }) => {
       dispatch({ type: LOADING_ON });
       const { user, token } = await handleLogin(data);
       if (token) {
-        dispatch({ type: LOGIN, payload: user }); // 로그인 성공 시, currentUser의 정보 갱신
+        dispatch({ type: LOGIN, payload: user }); 
       }
       dispatch({ type: LOADING_OFF });
     },
@@ -63,7 +63,7 @@ const UserProvider = ({ children }) => {
       const res = await handleSignup(data);
 
       if (res.token) {
-        dispatch({ type: SIGNUP, payload: res.user }); // 회원가입 성공 시, currentUser의 정보 갱신
+        dispatch({ type: SIGNUP, payload: res.user }); 
       }
       dispatch({ type: LOADING_OFF });
     },
@@ -73,11 +73,10 @@ const UserProvider = ({ children }) => {
   const onLogout = useCallback(async () => {
     dispatch({ type: LOADING_ON });
     handleLogout();
-    dispatch({ type: LOGOUT }); // 로그아웃 후, currentUser의 정보 갱신(초기화)
+    dispatch({ type: LOGOUT }); 
     dispatch({ type: LOADING_OFF });
   }, [handleLogout]);
 
-  // 특정 유저를 팔로우한 경우, currentUser의 정보 갱신
   const onFollow = useCallback(
     async (payload = { userId: '', followId: '' }) => {
       const data = await handlefollow(payload.userId);
@@ -86,7 +85,6 @@ const UserProvider = ({ children }) => {
     [handlefollow],
   );
 
-  // 특정 유저를 언팔로우한 경우, currentUser의 정보 갱신
   const onUnfollow = useCallback(
     (payload = { unfollowId: '' }) => {
       handleUnFollow(payload.unfollowId);
@@ -95,7 +93,6 @@ const UserProvider = ({ children }) => {
     [handleUnFollow],
   );
 
-  //현재 유저의 닉네임을 수정
   const onChangeFullName = useCallback(
     (payload = { fullName: '', username: '' }) => {
       const { fullName, username } = payload;
@@ -105,7 +102,6 @@ const UserProvider = ({ children }) => {
     [handlechangeUserName],
   );
 
-  //현재 유저의 프로필 사진 수정
   const onChangeProfile = useCallback(
     (payload = { image: '' }) => {
       handlechangeProfile(payload);

--- a/src/hooks/useSWRPostList.js
+++ b/src/hooks/useSWRPostList.js
@@ -1,0 +1,63 @@
+import { useUserContext } from 'contexts/UserContext';
+import useSWR from 'swr';
+
+export const postListKey = `/posts/channel/${process.env.REACT_APP_CHANNEL_ID}?offset=0&limit=5`;
+
+const useSWRPostList = () => {
+  const { data, error, isValidating, mutate } = useSWR(postListKey);
+  const { currentUser } = useUserContext();
+
+  const mutateLike = (type, index, like) => {
+    if (!data) {
+      return;
+    }
+
+    const initialPostList = [...data];
+    const currentPost = initialPostList[index];
+    let updatedPost;
+
+    switch (type) {
+      case 'LIKE': {
+        updatedPost = {
+          ...currentPost,
+          likes: [...currentPost.likes, like],
+        };
+        break;
+      }
+      case 'DISLIKE': {
+        updatedPost = {
+          ...currentPost,
+          likes: currentPost.likes.filter(({ user }) => user !== currentUser.id),
+        };
+        break;
+      }
+    }
+
+    const updatedPostList = [
+      ...initialPostList.slice(0, index),
+      updatedPost,
+      ...initialPostList.slice(index + 1),
+    ];
+    mutate(updatedPostList, {
+      revalidate: false,
+    });
+  };
+
+  const mutateDeletion = (postId) => {
+    const updatedPostList = data.filter(({ _id }) => _id !== postId);
+    mutate(updatedPostList, {
+      revalidate: true,
+    });
+  };
+
+  return {
+    data,
+    error,
+    isValidating,
+    mutate,
+    mutateLike,
+    mutateDeletion,
+  };
+};
+
+export default useSWRPostList;

--- a/src/hooks/useScrollPosition.js
+++ b/src/hooks/useScrollPosition.js
@@ -1,5 +1,0 @@
-import useSessionStorage from './useSessionStorage';
-
-const SCROLL_POSITION_KEY = 'prevPostIndex';
-
-export default () => useSessionStorage(SCROLL_POSITION_KEY, 0);

--- a/src/pages/MainPage/PostBody.jsx
+++ b/src/pages/MainPage/PostBody.jsx
@@ -30,6 +30,7 @@ const PostBody = ({ index, post, isDetailPage = false }) => {
   const { currentUser } = useUserContext();
   const navigate = useNavigate();
   const { mutateLike } = useSWRPostList();
+  const prefetchTimer = useRef(null);
 
   useEffect(() => {
     const myLikeIndex = likes.findIndex(({ user }) => user === currentUser.id);
@@ -102,8 +103,15 @@ const PostBody = ({ index, post, isDetailPage = false }) => {
   };
 
   const PrefetchPostData = () => {
-    !isDetailPage &&
-      mutatePostDetail(`/posts/${postId}`, () => swrOptions.fetcher(`/posts/${postId}`));
+    if (!isDetailPage) {
+      prefetchTimer.current = setTimeout(() => {
+        mutatePostDetail(`/posts/${postId}`, () => swrOptions.fetcher(`/posts/${postId}`));
+      }, 500);
+    }
+  };
+
+  const cancelPrefetch = () => {
+    clearTimeout(prefetchTimer.current);
   };
 
   return (
@@ -112,6 +120,7 @@ const PostBody = ({ index, post, isDetailPage = false }) => {
         onClick={navigateToDetailPage}
         isDetailPage={isDetailPage}
         onMouseEnter={PrefetchPostData}
+        onMouseLeave={cancelPrefetch}
         onTouchStart={PrefetchPostData}
       >
         <Image

--- a/src/pages/MainPage/PostBody.jsx
+++ b/src/pages/MainPage/PostBody.jsx
@@ -102,11 +102,11 @@ const PostBody = ({ index, post, isDetailPage = false }) => {
     setModalOn(false);
   };
 
-  const PrefetchPostData = () => {
+  const prefetchPostData = () => {
     if (!isDetailPage) {
       prefetchTimer.current = setTimeout(() => {
         mutatePostDetail(`/posts/${postId}`, () => swrOptions.fetcher(`/posts/${postId}`));
-      }, 500);
+      }, 1000);
     }
   };
 
@@ -119,9 +119,10 @@ const PostBody = ({ index, post, isDetailPage = false }) => {
       <ImageWrapper
         onClick={navigateToDetailPage}
         isDetailPage={isDetailPage}
-        onMouseEnter={PrefetchPostData}
+        onMouseEnter={prefetchPostData}
         onMouseLeave={cancelPrefetch}
-        onTouchStart={PrefetchPostData}
+        onTouchStart={prefetchPostData}
+        onTouchEnd={cancelPrefetch}
       >
         <Image
           src={image ? image : IMAGE_URLS.POST_DEFAULT_IMG}

--- a/src/pages/MainPage/PostHeader.jsx
+++ b/src/pages/MainPage/PostHeader.jsx
@@ -7,8 +7,9 @@ import theme from 'styles/theme';
 import useLocalToken from 'hooks/useLocalToken';
 import IconButton from 'components/basic/Icon/IconButton';
 import { MORE } from 'utils/constants/icons/names';
+import useSWRPostList from 'hooks/useSWRPostList';
 
-const PostHeader = ({ post, isDetailPage }) => {
+const PostHeader = ({ index, post, isDetailPage }) => {
   const {
     _id: postId,
     author: { _id, image, fullName },
@@ -17,6 +18,7 @@ const PostHeader = ({ post, isDetailPage }) => {
   const navigate = useNavigate();
   const [isModal, setIsModal] = useState(false);
   const [localToken] = useLocalToken();
+  const { mutateDeletion } = useSWRPostList();
 
   const handleClickProfile = () => {
     navigate(`/user/${_id}`, {
@@ -44,6 +46,7 @@ const PostHeader = ({ post, isDetailPage }) => {
     if (localToken && postId) {
       await onDeletePost(postId);
       navigate(-1);
+      index < 5 && mutateDeletion(postId);
     }
   };
 

--- a/src/pages/MainPage/PostItem.jsx
+++ b/src/pages/MainPage/PostItem.jsx
@@ -6,7 +6,7 @@ import theme from 'styles/theme';
 const PostItem = ({ index, post, isDetailPage }) => {
   return (
     <Article>
-      <PostHeader post={post} isDetailPage={isDetailPage} />
+      <PostHeader index={index} post={post} isDetailPage={isDetailPage} />
       <PostBody index={index} post={post} isDetailPage={isDetailPage} />
     </Article>
   );

--- a/src/pages/MainPage/index.jsx
+++ b/src/pages/MainPage/index.jsx
@@ -15,7 +15,7 @@ const MainPage = () => {
   const targetRef = useRef(null);
 
   const { data: initialPosts } = useSWR(
-    `/posts/channel/${process.env.REACT_APP_CHANNEL_ID_TOTAL}?offset=0&limit=5`,
+    `/posts/channel/${process.env.REACT_APP_CHANNEL_ID}?offset=0&limit=5`,
   );
 
   useEffect(() => {

--- a/src/pages/MainPage/index.jsx
+++ b/src/pages/MainPage/index.jsx
@@ -3,7 +3,7 @@ import { PageWrapper, Spinner } from 'components';
 import { getPostsPart } from 'utils/apis/postApi';
 import PostItem from './PostItem';
 import { useState, useEffect, useRef } from 'react';
-import useSWR from 'swr';
+import useSWRPostList from 'hooks/useSWRPostList';
 
 const LIMIT = 5;
 
@@ -13,10 +13,7 @@ const MainPage = () => {
   const [offset, setOffset] = useState(0);
   const [max, setMax] = useState(0);
   const targetRef = useRef(null);
-
-  const { data: initialPosts } = useSWR(
-    `/posts/channel/${process.env.REACT_APP_CHANNEL_ID}?offset=0&limit=5`,
-  );
+  const { data: initialPosts } = useSWRPostList();
 
   useEffect(() => {
     if (initialPosts) {

--- a/src/pages/MainPage/index.jsx
+++ b/src/pages/MainPage/index.jsx
@@ -13,27 +13,18 @@ const MainPage = () => {
   const [offset, setOffset] = useState(0);
   const [max, setMax] = useState(0);
   const targetRef = useRef(null);
-  const [prevPostIndex, setPrevPostIndex] = useScrollPosition();
 
   useEffect(() => {
-    const limit = prevPostIndex ? prevPostIndex : LIMIT;
     (async () => {
       const { data: nextPosts } = await getPostsPart({
         offset,
-        limit,
+        limit: LIMIT,
       });
       setPosts(nextPosts);
       setMax(nextPosts[0].channel.posts.length);
-      setOffset(prevPostIndex ? prevPostIndex : LIMIT);
+      setOffset(LIMIT);
     })();
   }, []);
-
-  useEffect(() => {
-    if (targetRef.current && prevPostIndex) {
-      window.scrollTo(0, document.body.scrollHeight);
-      setPrevPostIndex(0);
-    }
-  }, [targetRef, prevPostIndex, setPrevPostIndex]);
 
   const onIntersect = useCallback(
     async ([entry], observer) => {

--- a/src/pages/MainPage/index.jsx
+++ b/src/pages/MainPage/index.jsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { PageWrapper } from 'components';
+import { PageWrapper, Spinner } from 'components';
 import { getPostsPart } from 'utils/apis/postApi';
 import PostItem from './PostItem';
 import { useState, useEffect, useCallback, useRef } from 'react';
@@ -74,6 +74,7 @@ const MainPage = () => {
           );
         })}
       </PostList>
+      <Spinner loading={isLoading} />
     </PageWrapper>
   );
 };

--- a/src/pages/MainPage/index.jsx
+++ b/src/pages/MainPage/index.jsx
@@ -3,6 +3,7 @@ import { PageWrapper, Spinner } from 'components';
 import { getPostsPart } from 'utils/apis/postApi';
 import PostItem from './PostItem';
 import { useState, useEffect, useRef } from 'react';
+import useSWR from 'swr';
 
 const LIMIT = 5;
 
@@ -13,17 +14,17 @@ const MainPage = () => {
   const [max, setMax] = useState(0);
   const targetRef = useRef(null);
 
+  const { data: initialPosts } = useSWR(
+    `/posts/channel/${process.env.REACT_APP_CHANNEL_ID_TOTAL}?offset=0&limit=5`,
+  );
+
   useEffect(() => {
-    (async () => {
-      const { data: nextPosts } = await getPostsPart({
-        offset,
-        limit: LIMIT,
-      });
-      setPosts(nextPosts);
-      setMax(nextPosts[0].channel.posts.length);
+    if (initialPosts) {
+      setPosts([...initialPosts]);
+      setMax(initialPosts[0].channel.posts.length);
       setOffset(offset + LIMIT);
-    })();
-  }, []);
+    }
+  }, [initialPosts]);
 
   const onIntersect = async ([entry], observer) => {
     if (entry.isIntersecting && !isLoading && offset < max) {

--- a/src/pages/MainPage/index.jsx
+++ b/src/pages/MainPage/index.jsx
@@ -2,8 +2,7 @@ import styled from '@emotion/styled';
 import { PageWrapper, Spinner } from 'components';
 import { getPostsPart } from 'utils/apis/postApi';
 import PostItem from './PostItem';
-import { useState, useEffect, useCallback, useRef } from 'react';
-import useScrollPosition from 'hooks/useScrollPosition';
+import { useState, useEffect, useRef } from 'react';
 
 const LIMIT = 5;
 
@@ -22,26 +21,23 @@ const MainPage = () => {
       });
       setPosts(nextPosts);
       setMax(nextPosts[0].channel.posts.length);
-      setOffset(LIMIT);
+      setOffset(offset + LIMIT);
     })();
   }, []);
 
-  const onIntersect = useCallback(
-    async ([entry], observer) => {
-      if (entry.isIntersecting && !isLoading && offset < max) {
-        observer.disconnect();
-        setIsLoading(true);
-        setOffset(offset + 5);
-        const nextPosts = await getPostsPart({
-          offset,
-          limit: LIMIT,
-        }).then((res) => res.data);
-        setPosts([...posts, ...nextPosts]);
-        setIsLoading(false);
-      }
-    },
-    [isLoading, offset, max, posts],
-  );
+  const onIntersect = async ([entry], observer) => {
+    if (entry.isIntersecting && !isLoading && offset < max) {
+      observer.disconnect();
+      setIsLoading(true);
+      setOffset(offset + 5);
+      const { data: nextPosts } = await getPostsPart({
+        offset,
+        limit: LIMIT,
+      });
+      setPosts([...posts, ...nextPosts]);
+      setIsLoading(false);
+    }
+  };
 
   useEffect(() => {
     let observer;
@@ -52,7 +48,7 @@ const MainPage = () => {
       observer.observe(targetRef.current);
     }
     return () => observer && observer.disconnect();
-  }, [onIntersect]);
+  }, [posts.length]);
 
   return (
     <PageWrapper header nav info>

--- a/src/utils/apis/common.js
+++ b/src/utils/apis/common.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const instance = axios.create({
+export const instance = axios.create({
   timeout: 5000,
 });
 

--- a/src/utils/apis/postApi.js
+++ b/src/utils/apis/postApi.js
@@ -10,7 +10,7 @@ export const channelId = '62b20b485baf8c52bfe6d453';
 export const getPosts = () => {
   return request({
     method: API_METHOD.GET,
-    url: `/posts/channel/${channelId}`,
+    url: `/posts/channel/${process.env.REACT_APP_CHANNEL_ID}`,
   });
 };
 
@@ -21,7 +21,7 @@ export const getPosts = () => {
 export const getPostsPart = ({ offset, limit }) => {
   return request({
     method: API_METHOD.GET,
-    url: `/posts/channel/${channelId}`,
+    url: `/posts/channel/${process.env.REACT_APP_CHANNEL_ID}`,
     params: {
       offset,
       limit,

--- a/src/utils/apis/swrOptions.js
+++ b/src/utils/apis/swrOptions.js
@@ -1,0 +1,8 @@
+import { instance } from './common';
+
+export const swrOptions = {
+  fetcher: async (url) => {
+    const { data } = await instance.get(url);
+    return data;
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -13283,6 +13283,11 @@ svgo@^2.7.0:
     picocolors "^1.0.0"
     stable "^0.1.8"
 
+swr@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-1.3.0.tgz#c6531866a35b4db37b38b72c45a63171faf9f4e8"
+  integrity sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz"


### PR DESCRIPTION
## ✅ 이슈 번호
#212

## 📌 기능 설명 <!-- 기능을 대략적으로 설명해주세요 -->

SWR을 도입하여
'메인페이지', '게시물 상세 페이지'의 성능을 보완했습니다.

두 페이지에서 사용하는 API의 성능이 상당히 느립니다.
예를 들어, 5개의 게시물을 불러오는 데 약 1s 가량 소요됩니다.
이 때문에 페이지의 전환 속도가 꽤 느립니다.

SWR의 '캐싱'과 '프리패칭'을 통해서 이를 보완했습니다.
댓글 UI에도 SWR을 적용하여 서버와의 동기화를 높였습니다.
그 외 무한스크롤 시 Spinner를 추가했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 요구 사항과 실제 구현 내용을 작성해 주세요 -->

- [x] SWR 전역 옵션 설정
- [x] 캐시 적용 (Main, PostDetail)
- [x] 데이터 프리패칭 (PostDetail)
- [x] 댓글 데이터의 실시간 갱신 (PostDetail)
- [x] 무한스크롤 시 Spinner 추가 (Main)


